### PR TITLE
체크박스 컴포넌트 

### DIFF
--- a/public/svg/icons/icon_checked.svg
+++ b/public/svg/icons/icon_checked.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M9 22H15C20 22 22 20 22 15V9C22 4 20 2 15 2H9C4 2 2 4 2 9V15C2 20 4 22 9 22Z" fill="#F5535D" stroke="#F5535D" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M7.75 12L10.58 14.83L16.25 9.17" stroke="white" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/public/svg/icons/icon_radio_checked.svg
+++ b/public/svg/icons/icon_radio_checked.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22Z" fill="#F5535D"/>
+<path d="M8.46997 10.74L12 14.26L15.53 10.74" stroke="white" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/public/svg/icons/icon_radio_unchecked.svg
+++ b/public/svg/icons/icon_radio_unchecked.svg
@@ -1,0 +1,3 @@
+<svg width="22" height="22" viewBox="0 0 22 22" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M11 21C16.5228 21 21 16.5228 21 11C21 5.47715 16.5228 1 11 1C5.47715 1 1 5.47715 1 11C1 16.5228 5.47715 21 11 21Z" stroke="#F1F1F5" stroke-width="1.5" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/public/svg/icons/icon_unchecked.svg
+++ b/public/svg/icons/icon_unchecked.svg
@@ -1,0 +1,3 @@
+<svg width="22" height="22" viewBox="0 0 22 22" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M8 21H14C19 21 21 19 21 14V8C21 3 19 1 14 1H8C3 1 1 3 1 8V14C1 19 3 21 8 21Z" stroke="#F5535D" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/components/common/Checkbox.tsx
+++ b/src/components/common/Checkbox.tsx
@@ -4,7 +4,15 @@ import check from '@public/svg/icons/icon_checked.svg';
 import uncheck from '@public/svg/icons/icon_unchecked.svg';
 import checkRadio from '@public/svg/icons/icon_radio_checked.svg';
 import unCheckRadio from '@public/svg/icons/icon_radio_unchecked.svg';
+import tw from 'tailwind-styled-components/dist/tailwind';
+interface defaultProps {
+  [key: string]: any;
+}
 
+const Label = tw.label<defaultProps>`w-full flex items-center`;
+const CheckBoxSpan = tw.span<defaultProps>`flex items-center justify-center rounded-sm mr-2`;
+const CheckBoxInnerSpan = tw.span`text-14`;
+const CheckBoxInput = tw.input`hidden`;
 interface CheckBoxProps {
   kind?: 'checkbox' | 'radio';
   label?: string;
@@ -19,52 +27,50 @@ export default function CheckBox({
   const [isCheck, setIsCheck] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
   return kind === 'checkbox' ? (
-    <label className="w-full flex items-center">
-      <span
+    <Label>
+      <CheckBoxSpan
         onClick={() => {
           if (!inputRef) return;
           setIsCheck(!inputRef.current?.checked);
         }}
-        className="flex items-center justify-center rounded-sm mr-2"
       >
         {isCheck ? (
           <Image src={check} alt="checkd" width={20} height={20} />
         ) : (
           <Image src={uncheck} alt="uncheckd" width={20} height={20} />
         )}
-      </span>
-      <span className="text-14">{label}</span>
-      <input
+      </CheckBoxSpan>
+      <CheckBoxInnerSpan>{label}</CheckBoxInnerSpan>
+      <CheckBoxInput
         id="checkobx"
         ref={inputRef}
         type="checkbox"
         className="hidden"
         {...rest}
       />
-    </label>
+    </Label>
   ) : (
-    <label className="w-full flex items-center">
-      <span
+    <Label>
+      <CheckBoxSpan
         onClick={() => {
           if (!inputRef) return;
           setIsCheck(!inputRef.current?.checked);
         }}
-        className="flex items-center justify-center rounded-sm mr-2"
       >
         {isCheck ? (
           <Image src={checkRadio} alt="checkd" width={20} height={20} />
         ) : (
           <Image src={unCheckRadio} alt="uncheckd" width={20} height={20} />
         )}
-      </span>
-      <span className="text-14">{label}</span>
-      <input
+      </CheckBoxSpan>
+      <CheckBoxInnerSpan>{label}</CheckBoxInnerSpan>
+      <CheckBoxInput
         id="checkobx"
         ref={inputRef}
         type="checkbox"
         className="hidden"
         {...rest}
       />
-    </label>
+    </Label>
   );
 }

--- a/src/components/common/Checkbox.tsx
+++ b/src/components/common/Checkbox.tsx
@@ -1,0 +1,70 @@
+import Image from 'next/image';
+import { useRef, useState } from 'react';
+import check from '@public/svg/icons/icon_checked.svg';
+import uncheck from '@public/svg/icons/icon_unchecked.svg';
+import checkRadio from '@public/svg/icons/icon_radio_checked.svg';
+import unCheckRadio from '@public/svg/icons/icon_radio_unchecked.svg';
+
+interface CheckBoxProps {
+  kind?: 'checkbox' | 'radio';
+  label?: string;
+  [key: string]: any;
+}
+
+export default function CheckBox({
+  label,
+  kind = 'checkbox',
+  ...rest
+}: CheckBoxProps) {
+  const [isCheck, setIsCheck] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+  return kind === 'checkbox' ? (
+    <label className="w-full flex items-center">
+      <span
+        onClick={() => {
+          if (!inputRef) return;
+          setIsCheck(!inputRef.current?.checked);
+        }}
+        className="flex items-center justify-center rounded-sm mr-2"
+      >
+        {isCheck ? (
+          <Image src={check} alt="checkd" width={20} height={20} />
+        ) : (
+          <Image src={uncheck} alt="uncheckd" width={20} height={20} />
+        )}
+      </span>
+      <span className="text-14">{label}</span>
+      <input
+        id="checkobx"
+        ref={inputRef}
+        type="checkbox"
+        className="hidden"
+        {...rest}
+      />
+    </label>
+  ) : (
+    <label className="w-full flex items-center">
+      <span
+        onClick={() => {
+          if (!inputRef) return;
+          setIsCheck(!inputRef.current?.checked);
+        }}
+        className="flex items-center justify-center rounded-sm mr-2"
+      >
+        {isCheck ? (
+          <Image src={checkRadio} alt="checkd" width={20} height={20} />
+        ) : (
+          <Image src={unCheckRadio} alt="uncheckd" width={20} height={20} />
+        )}
+      </span>
+      <span className="text-14">{label}</span>
+      <input
+        id="checkobx"
+        ref={inputRef}
+        type="checkbox"
+        className="hidden"
+        {...rest}
+      />
+    </label>
+  );
+}

--- a/src/pages/auth/join.tsx
+++ b/src/pages/auth/join.tsx
@@ -1,4 +1,4 @@
-import Layout from '@components/common/layout';
+import Layout from '@components/common/Layout';
 import { useForm } from 'react-hook-form';
 
 function Join() {

--- a/src/pages/auth/login.tsx
+++ b/src/pages/auth/login.tsx
@@ -1,4 +1,4 @@
-import Layout from '@components/common/layout';
+import Layout from '@components/common/Layout';
 import Link from 'next/link';
 import { useForm } from 'react-hook-form';
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,7 +21,8 @@
       "@constants/*": ["./constants/*"],
       "@features/*": ["./features/*"],
       "@hooks/*": ["./hooks/*"],
-      "@utils/*": ["./utils/*"]
+      "@utils/*": ["./utils/*"],
+      "@public/*": ["../public/*"]
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],


### PR DESCRIPTION
## 🧑‍💻 PR 내용

체크박스 컴포넌트를 만들었습니다.
kind = 'checkbox' | 'radio'를 props로 받습니다(default는 'checkbox')
label props를 넘겨주면 체크박스 옆에 라벨이 나타납니다.
## 📸 스크린샷

<img width="185" alt="image" src="https://user-images.githubusercontent.com/92621861/209274932-e1f38e70-2440-4b7e-aeb9-bf68ec8eeb9e.png">
<img width="158" alt="image" src="https://user-images.githubusercontent.com/92621861/209275625-f95f7db2-c849-4169-9ecc-b7ebd5154551.png">
