### PR TITLE
회원가입 약관 동의 페이지 구현

### DIFF
--- a/public/svg/icons/icon_arrow.svg
+++ b/public/svg/icons/icon_arrow.svg
@@ -1,0 +1,3 @@
+<svg width="9" height="16" viewBox="0 0 9 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M0.999999 1L8 8L1 15" stroke="#999999" stroke-width="1.91467" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/components/common/Checkbox.tsx
+++ b/src/components/common/Checkbox.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import Image from 'next/image';
 import { useRef, useState } from 'react';
 import check from '@public/svg/icons/icon_checked.svg';
@@ -14,38 +15,40 @@ const CheckBoxSpan = tw.span<defaultProps>`flex items-center justify-center roun
 const CheckBoxInnerSpan = tw.span`text-12`;
 const CheckBoxInput = tw.input`hidden`;
 interface CheckBoxProps {
+  id?: string;
   kind?: 'checkbox' | 'radio';
   label?: string;
+  isChecked: boolean;
+  handler(e: React.ChangeEvent<HTMLInputElement>): void;
   [key: string]: any;
 }
 
 export default function CheckBox({
+  id,
   label,
   kind = 'checkbox',
+  isChecked,
+  handler,
   ...rest
 }: CheckBoxProps) {
   const [isCheck, setIsCheck] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
   return kind === 'checkbox' ? (
     <Label>
-      <CheckBoxSpan
-        onClick={() => {
-          if (!inputRef) return;
-          setIsCheck(!inputRef.current?.checked);
-        }}
-      >
-        {isCheck ? (
-          <Image src={check} alt="checkd" width={20} height={20} />
+      <CheckBoxSpan>
+        {isChecked ? (
+          <Image src={check} alt="checked" width={20} height={20} />
         ) : (
-          <Image src={uncheck} alt="uncheckd" width={20} height={20} />
+          <Image src={uncheck} alt="unchecked" width={20} height={20} />
         )}
       </CheckBoxSpan>
       <CheckBoxInnerSpan>{label}</CheckBoxInnerSpan>
       <CheckBoxInput
-        id="checkobx"
         ref={inputRef}
-        type="checkbox"
-        className="hidden"
+        id={id}
+        type={kind}
+        checked={isChecked}
+        onChange={handler}
         {...rest}
       />
     </Label>

--- a/src/pages/auth/join01.tsx
+++ b/src/pages/auth/join01.tsx
@@ -1,0 +1,137 @@
+import Image from 'next/image';
+import CheckBox from '@components/common/Checkbox';
+import Layout from '@components/common/Layout';
+import Button from '@components/common/Button';
+import tw from 'tailwind-styled-components';
+import arrowBtn from '@public/svg/icons/icon_arrow.svg';
+import backBtn from '@public/svg/icons/icon_back.svg';
+import closeBtn from '@public/svg/icons/icon_close.svg';
+import { useState } from 'react';
+
+interface defaultProps {
+  [key: string]: any;
+}
+
+const CheckBoxList = tw.li<defaultProps>`
+pb-[18px] flex justify-between
+`;
+
+export default function Join01() {
+  const [checkedTerm, setCheckedTerm] = useState<string[]>([]);
+
+  const onCheckedAll = (checked: boolean): void => {
+    if (checked) {
+      setCheckedTerm(() => ['term1', 'term2', 'term3', 'term4']);
+    } else if (
+      (!checked && checkedTerm.includes('term1')) ||
+      (!checked && checkedTerm.includes('term2')) ||
+      (!checked && checkedTerm.includes('term3')) ||
+      (!checked && checkedTerm.includes('term4'))
+    ) {
+      setCheckedTerm(() => []);
+    }
+    console.log(checkedTerm);
+  };
+
+  const onChecked = (checked: boolean, id: string): void => {
+    if (checked) {
+      setCheckedTerm(() => [...checkedTerm, id]);
+    } else if (!checked && checkedTerm.includes(id)) {
+      setCheckedTerm(() => checkedTerm.filter((el: string) => el !== id));
+    }
+  };
+
+  return (
+    <Layout>
+      <div className="flex justify-between pb-[44px]">
+        <button>
+          <Image src={backBtn} alt="back" width={10} height={12}></Image>
+        </button>
+        <h5 className="text-18 font-bold">회원가입</h5>
+        <button>
+          <Image src={closeBtn} alt="close" width={24} height={12}></Image>
+        </button>
+      </div>
+      <form autoComplete="off">
+        <div className="pb-[18px]">
+          <CheckBox
+            id="selectAll"
+            label="전체동의"
+            isChecked={checkedTerm.length === 4 ? true : false}
+            handler={(e) => onCheckedAll(e.target.checked)}
+          />
+        </div>
+        <div>
+          <ul>
+            <CheckBoxList>
+              <CheckBox
+                kind="checkbox"
+                id="term1"
+                label="아띠즈 이용약관 동의(필수)"
+                isChecked={checkedTerm.includes('term1') ? true : false}
+                handler={(e) => onChecked(e.target.checked, e.target.id)}
+              />
+              <button>
+                <Image
+                  src={arrowBtn}
+                  alt="arrowBtn"
+                  width={7}
+                  height={14}
+                ></Image>
+              </button>
+            </CheckBoxList>
+            <CheckBoxList>
+              <CheckBox
+                id="term2"
+                label="개인정보 수집과 이용에 동의(필수)"
+                isChecked={checkedTerm.includes('term2') ? true : false}
+                handler={(e) => onChecked(e.target.checked, e.target.id)}
+              />
+              <button>
+                <Image
+                  src={arrowBtn}
+                  alt="arrowBtn"
+                  width={7}
+                  height={14}
+                ></Image>
+              </button>
+            </CheckBoxList>
+            <CheckBoxList>
+              <CheckBox
+                id="term3"
+                label="위치정보 이용약관에 동의(필수)"
+                isChecked={checkedTerm.includes('term3') ? true : false}
+                handler={(e) => onChecked(e.target.checked, e.target.id)}
+              />
+              <button>
+                <Image
+                  src={arrowBtn}
+                  alt="arrowBtn"
+                  width={7}
+                  height={14}
+                ></Image>
+              </button>
+            </CheckBoxList>
+            <CheckBoxList>
+              <CheckBox
+                id="term4"
+                label="아띠즈 이벤트와 프로모션 수신 동의(선택)"
+                isChecked={checkedTerm.includes('term4') ? true : false}
+                handler={(e) => onChecked(e.target.checked, e.target.id)}
+              />
+              <button>
+                <Image
+                  src={arrowBtn}
+                  alt="arrowBtn"
+                  width={7}
+                  height={14}
+                ></Image>
+              </button>
+            </CheckBoxList>
+          </ul>
+        </div>
+      </form>
+      <Button text="확인" className="mt-[300px]"></Button>
+    </Layout>
+  );
+}


### PR DESCRIPTION
## 🧑‍💻 PR 내용

기존 공통 체크박스 컴포넌트에서 checked prop을 추가하여 전체 선택, 선택 기능을 구현했습니다.

공통 회원가입 01 페이지를 구현했습니다.

icons 폴더에 icon_arrow.svg 파일을 추가했습니다.

## 📸 스크린샷

![image](https://user-images.githubusercontent.com/79186378/209507769-dc03a0ca-bc9d-44ff-b7e7-f8001f99d55d.png)

