### PR TITLE
rtk 세팅 및 회원가입 절차에 전역변수 적용 외 기능 구현

### DIFF
--- a/src/components/common/ErrorMessage.tsx
+++ b/src/components/common/ErrorMessage.tsx
@@ -4,14 +4,6 @@ interface ErrorMessageProps {
   message: any;
 }
 
-interface defaultProps {
-  [key: string]: any;
-}
-
-const ErrorTag = tw.span<defaultProps>`
-text-[#FF3120] text-14
-`;
-
 export default function ErrorMessage({ message }: ErrorMessageProps) {
-  return <ErrorTag>{message}</ErrorTag>;
+  return <span className="text-14 text-[#FF3120]">{message}</span>;
 }

--- a/src/features/user/userSlice.ts
+++ b/src/features/user/userSlice.ts
@@ -10,7 +10,7 @@ type userInfo = {
 interface userState extends userInfo {
   tastes: string[];
   isApprovePromotion: boolean;
-  iaAuthor: boolean;
+  isAuthor: boolean;
 }
 
 const initialState: userState = {
@@ -21,7 +21,7 @@ const initialState: userState = {
   tel: '',
   tastes: [],
   isApprovePromotion: false,
-  iaAuthor: false,
+  isAuthor: false,
 };
 
 const userSlice = createSlice({
@@ -54,6 +54,6 @@ const userSlice = createSlice({
   },
 });
 
-export const { setUserinfo, setTastes, setIsApprovePromotion } =
+export const { setUserinfo, setTastes, setIsApprovePromotion, setIsAuthor } =
   userSlice.actions;
 export default userSlice.reducer;

--- a/src/features/user/userSlice.ts
+++ b/src/features/user/userSlice.ts
@@ -28,7 +28,7 @@ const userSlice = createSlice({
   name: 'userReducer',
   initialState,
   reducers: {
-    setUserinfo: (state: userState, action: PayloadAction<userInfo>) => ({
+    setUserInfo: (state: userState, action: PayloadAction<userInfo>) => ({
       ...state,
       id: action.payload.id,
       password: action.payload.password,
@@ -54,6 +54,6 @@ const userSlice = createSlice({
   },
 });
 
-export const { setUserinfo, setTastes, setIsApprovePromotion, setIsAuthor } =
+export const { setUserInfo, setTastes, setIsApprovePromotion, setIsAuthor } =
   userSlice.actions;
 export default userSlice.reducer;

--- a/src/features/user/userSlice.ts
+++ b/src/features/user/userSlice.ts
@@ -1,14 +1,18 @@
-import { createSlice } from '@reduxjs/toolkit';
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
-interface userState {
+type userInfo = {
   id: string;
   password: string;
   email: string;
   username: string;
   tel: string;
+};
+interface userState extends userInfo {
   tastes: string[];
   isApprovePromotion: boolean;
+  iaAuthor: boolean;
 }
+
 const initialState: userState = {
   id: '',
   password: '',
@@ -17,13 +21,14 @@ const initialState: userState = {
   tel: '',
   tastes: [],
   isApprovePromotion: false,
+  iaAuthor: false,
 };
 
 const userSlice = createSlice({
   name: 'userReducer',
   initialState,
   reducers: {
-    setUserinfo: (state, action) => ({
+    setUserinfo: (state: userState, action: PayloadAction<userInfo>) => ({
       ...state,
       id: action.payload.id,
       password: action.payload.password,
@@ -31,13 +36,20 @@ const userSlice = createSlice({
       username: action.payload.username,
       tel: action.payload.tel,
     }),
-    setTastes: (state, action) => ({
+    setTastes: (state: userState, action: PayloadAction<string[]>) => ({
       ...state,
       tastes: action.payload,
     }),
-    setIsApprovePromotion: (state, action) => ({
+    setIsApprovePromotion: (
+      state: userState,
+      action: PayloadAction<boolean>,
+    ) => ({
       ...state,
       isApprovePromotion: action.payload,
+    }),
+    setIsAuthor: (state: userState, action: PayloadAction<boolean>) => ({
+      ...state,
+      isAuthor: action.payload,
     }),
   },
 });

--- a/src/features/user/userSlice.ts
+++ b/src/features/user/userSlice.ts
@@ -1,31 +1,66 @@
 import { createSlice } from '@reduxjs/toolkit';
 
 interface userState {
-  university: string;
-  admissonYear: string;
+  id: string;
+  password: string;
   email: string;
+  username: string;
+  phone: string;
+  tastes: string[];
+  isApprovePromotion: boolean;
 }
 const initialState: userState = {
-  university: '',
-  admissonYear: '',
+  id: '',
+  password: '',
   email: '',
+  username: '',
+  phone: '',
+  tastes: [],
+  isApprovePromotion: false,
 };
 
 const userSlice = createSlice({
   name: 'userReducer',
   initialState,
   reducers: {
-    setUniversity: (state, action) => ({
+    setId: (state, action) => ({
       ...state,
-      university: action.payload,
+      Id: action.payload,
     }),
-    setAdmissionYear: (state, action) => ({
+    setPassword: (state, action) => ({
       ...state,
-      admissonYear: action.payload,
+      password: action.payload,
     }),
-    setEmail: (state, action) => ({ ...state, email: action.payload }),
+    setEmail: (state, action) => ({
+      ...state,
+      email: action.payload,
+    }),
+    setUsername: (state, action) => ({
+      ...state,
+      username: action.payload,
+    }),
+    setPhone: (state, action) => ({
+      ...state,
+      phone: action.payload,
+    }),
+    setTastes: (state, action) => ({
+      ...state,
+      tastes: action.payload,
+    }),
+    setIsApprovePromotion: (state, action) => ({
+      ...state,
+      isApprovePromotion: action.payload,
+    }),
   },
 });
 
-export const { setUniversity, setAdmissionYear, setEmail } = userSlice.actions;
+export const {
+  setId,
+  setPassword,
+  setEmail,
+  setUsername,
+  setPhone,
+  setTastes,
+  setIsApprovePromotion,
+} = userSlice.actions;
 export default userSlice.reducer;

--- a/src/features/user/userSlice.ts
+++ b/src/features/user/userSlice.ts
@@ -23,25 +23,13 @@ const userSlice = createSlice({
   name: 'userReducer',
   initialState,
   reducers: {
-    setId: (state, action) => ({
+    setUserinfo: (state, action) => ({
       ...state,
-      Id: action.payload,
-    }),
-    setPassword: (state, action) => ({
-      ...state,
-      password: action.payload,
-    }),
-    setEmail: (state, action) => ({
-      ...state,
-      email: action.payload,
-    }),
-    setUsername: (state, action) => ({
-      ...state,
-      username: action.payload,
-    }),
-    setTel: (state, action) => ({
-      ...state,
-      tel: action.payload,
+      id: action.payload.id,
+      password: action.payload.password,
+      email: action.payload.email,
+      username: action.payload.username,
+      tel: action.payload.tel,
     }),
     setTastes: (state, action) => ({
       ...state,
@@ -54,13 +42,6 @@ const userSlice = createSlice({
   },
 });
 
-export const {
-  setId,
-  setPassword,
-  setEmail,
-  setUsername,
-  setTel,
-  setTastes,
-  setIsApprovePromotion,
-} = userSlice.actions;
+export const { setUserinfo, setTastes, setIsApprovePromotion } =
+  userSlice.actions;
 export default userSlice.reducer;

--- a/src/features/user/userSlice.ts
+++ b/src/features/user/userSlice.ts
@@ -5,7 +5,7 @@ interface userState {
   password: string;
   email: string;
   username: string;
-  phone: string;
+  tel: string;
   tastes: string[];
   isApprovePromotion: boolean;
 }
@@ -14,7 +14,7 @@ const initialState: userState = {
   password: '',
   email: '',
   username: '',
-  phone: '',
+  tel: '',
   tastes: [],
   isApprovePromotion: false,
 };
@@ -39,9 +39,9 @@ const userSlice = createSlice({
       ...state,
       username: action.payload,
     }),
-    setPhone: (state, action) => ({
+    setTel: (state, action) => ({
       ...state,
-      phone: action.payload,
+      tel: action.payload,
     }),
     setTastes: (state, action) => ({
       ...state,
@@ -59,7 +59,7 @@ export const {
   setPassword,
   setEmail,
   setUsername,
-  setPhone,
+  setTel,
   setTastes,
   setIsApprovePromotion,
 } = userSlice.actions;

--- a/src/pages/auth/join.tsx
+++ b/src/pages/auth/join.tsx
@@ -5,7 +5,8 @@ import Image from 'next/image';
 import { useRouter } from 'next/router';
 import { useState } from 'react';
 import tw from 'tailwind-styled-components';
-
+import { useAppDispatch } from '@features/hooks';
+import { setIsAuthor as setIamAuthor } from '@features/user/userSlice';
 interface joinSelectProps {
   type: string;
   label?: string;
@@ -28,12 +29,12 @@ function Join() {
     router.back();
   };
 
+  const dispatch = useAppDispatch();
+
   const handleButtonClick = () => {
-    if (isUser) {
-      router.push('/auth/join01');
-    } else if (isAuthor) {
-      router.push('/auth/author/join01');
-    }
+    if (isUser) dispatch(setIamAuthor(false));
+    if (isAuthor) dispatch(setIamAuthor(true));
+    router.push('/auth/join01');
   };
   return (
     <Layout>

--- a/src/pages/auth/join01.tsx
+++ b/src/pages/auth/join01.tsx
@@ -8,7 +8,7 @@ import arrowBtn from '@public/svg/icons/icon_arrow.svg';
 import { useState } from 'react';
 import { useRouter } from 'next/router';
 import { useForm } from 'react-hook-form';
-import { useAppDispatch, useAppSelector } from '@features/hooks';
+import { useAppDispatch } from '@features/hooks';
 import { setIsApprovePromotion } from '@features/user/userSlice';
 interface defaultProps {
   [key: string]: any;

--- a/src/pages/auth/join01.tsx
+++ b/src/pages/auth/join01.tsx
@@ -7,7 +7,9 @@ import tw from 'tailwind-styled-components';
 import arrowBtn from '@public/svg/icons/icon_arrow.svg';
 import { useState } from 'react';
 import { useRouter } from 'next/router';
-
+import { useForm } from 'react-hook-form';
+import { useAppDispatch, useAppSelector } from '@features/hooks';
+import { setIsApprovePromotion } from '@features/user/userSlice';
 interface defaultProps {
   [key: string]: any;
 }
@@ -39,14 +41,31 @@ export default function Join01() {
     ) {
       setCheckedTerm(() => []);
     }
-    console.log(checkedTerm);
   };
-
   const onChecked = (checked: boolean, id: string): void => {
     if (checked) {
       setCheckedTerm(() => [...checkedTerm, id]);
     } else if (!checked && checkedTerm.includes(id)) {
       setCheckedTerm(() => checkedTerm.filter((el: string) => el !== id));
+    }
+  };
+
+  const dispatch = useAppDispatch();
+
+  const { handleSubmit } = useForm();
+  const onSubmit = () => {
+    if (checkedTerm.includes('term4')) {
+      dispatch(setIsApprovePromotion(true));
+    } else {
+      dispatch(setIsApprovePromotion(false));
+    }
+
+    if (
+      checkedTerm.includes('term1') &&
+      checkedTerm.includes('term2') &&
+      checkedTerm.includes('term3')
+    ) {
+      router.push('/auth/join02');
     }
   };
 
@@ -57,7 +76,7 @@ export default function Join01() {
         handleLeftButton={handleLeftButton}
         handleRightButton={handleRightButton}
       />
-      <form autoComplete="off">
+      <form onSubmit={handleSubmit(onSubmit)} autoComplete="off">
         <div className="mt-8 pb-[18px]">
           <CheckBox
             id="selectAll"
@@ -135,8 +154,8 @@ export default function Join01() {
             </CheckBoxList>
           </ul>
         </div>
+        <Button className="absolute bottom-[83px] w-[325px]" text="확인" />
       </form>
-      <Button className="absolute bottom-[83px] w-[325px]" text="확인" />
     </Layout>
   );
 }

--- a/src/pages/auth/join02.tsx
+++ b/src/pages/auth/join02.tsx
@@ -7,7 +7,7 @@ import Navigate from '@components/common/Navigate';
 import ErrorMessage from '@components/common/ErrorMessage';
 import { useRouter } from 'next/router';
 import { useAppDispatch, useAppSelector } from '@features/hooks';
-import { setUserinfo } from '@features/user/userSlice';
+import { setUserInfo } from '@features/user/userSlice';
 interface JoinForm {
   id: string;
   username: string;
@@ -39,7 +39,7 @@ export default function Join02() {
   const onSubmit = (form: JoinForm) => {
     const { id, username, password, tel, email } = form;
     dispatch(
-      setUserinfo({
+      setUserInfo({
         id,
         username,
         password,

--- a/src/pages/auth/join02.tsx
+++ b/src/pages/auth/join02.tsx
@@ -27,6 +27,7 @@ export default function Join02() {
   };
 
   const dispatch = useAppDispatch();
+  const userState = useAppSelector((state) => state.user);
 
   const {
     register,
@@ -47,7 +48,8 @@ export default function Join02() {
       }),
     );
 
-    router.push('/auth/join03');
+    if (userState.isAuthor) router.push('/auth/author/join01');
+    else router.push('/auth/user/join01');
   };
 
   return (
@@ -70,8 +72,8 @@ export default function Join02() {
             placeholder="아이디를 입력해주세요."
             register={register('id', { required: true })}
           />
+          {errors.id && <ErrorMessage message="이미 사용중인 아이디입니다." />}
         </section>
-        {errors.id && <ErrorMessage message="이미 사용중인 아이디입니다." />}
         <section className="mb-3">
           <Input
             type="text"

--- a/src/pages/auth/join02.tsx
+++ b/src/pages/auth/join02.tsx
@@ -6,6 +6,22 @@ import Button from '@components/common/Button';
 import Navigate from '@components/common/Navigate';
 import ErrorMessage from '@components/common/ErrorMessage';
 import { useRouter } from 'next/router';
+import { useAppDispatch } from '@features/hooks';
+import {
+  setEmail,
+  setId,
+  setPassword,
+  setTel,
+  setUsername,
+} from '@features/user/userSlice';
+interface JoinForm {
+  id: string;
+  username: string;
+  password: string;
+  confirmPassword: string;
+  tel: string;
+  email: string;
+}
 
 export default function Join02() {
   const router = useRouter();
@@ -16,15 +32,23 @@ export default function Join02() {
     router.push('/auth/login');
   };
 
+  const dispatch = useAppDispatch();
+
   const {
     register,
     handleSubmit,
     formState: { errors },
     watch,
-  } = useForm();
+  } = useForm<JoinForm>();
 
-  const onSubmit = (form) => {
-    console.log(form);
+  const onSubmit = (form: JoinForm) => {
+    const { id, username, password, tel, email } = form;
+    dispatch(setId(id));
+    dispatch(setUsername(username));
+    dispatch(setPassword(password));
+    dispatch(setTel(tel));
+    dispatch(setEmail(email));
+    router.push('/auth/join03');
   };
 
   return (
@@ -56,7 +80,7 @@ export default function Join02() {
             placeholder="이름을 입력해주세요."
             register={register('username', { required: true })}
           />
-          {errors.name && (
+          {errors.username && (
             <ErrorMessage message="최대 한글 25자 까지 입력 가능합니다." />
           )}
         </section>

--- a/src/pages/auth/join02.tsx
+++ b/src/pages/auth/join02.tsx
@@ -6,14 +6,8 @@ import Button from '@components/common/Button';
 import Navigate from '@components/common/Navigate';
 import ErrorMessage from '@components/common/ErrorMessage';
 import { useRouter } from 'next/router';
-import { useAppDispatch } from '@features/hooks';
-import {
-  setEmail,
-  setId,
-  setPassword,
-  setTel,
-  setUsername,
-} from '@features/user/userSlice';
+import { useAppDispatch, useAppSelector } from '@features/hooks';
+import { setUserinfo } from '@features/user/userSlice';
 interface JoinForm {
   id: string;
   username: string;
@@ -43,11 +37,16 @@ export default function Join02() {
 
   const onSubmit = (form: JoinForm) => {
     const { id, username, password, tel, email } = form;
-    dispatch(setId(id));
-    dispatch(setUsername(username));
-    dispatch(setPassword(password));
-    dispatch(setTel(tel));
-    dispatch(setEmail(email));
+    dispatch(
+      setUserinfo({
+        id,
+        username,
+        password,
+        tel,
+        email,
+      }),
+    );
+
     router.push('/auth/join03');
   };
 

--- a/src/pages/auth/join02.tsx
+++ b/src/pages/auth/join02.tsx
@@ -72,6 +72,7 @@ export default function Join02() {
                 message: '비밀번호를 형식에 맞게 입력해주세요.',
               },
             })}
+            className="rounded-b-none focus:translate-y-[-1px]"
           />
           <Input
             type="password"
@@ -84,7 +85,7 @@ export default function Join02() {
                 }
               },
             })}
-            className="border-t-0"
+            className="rounded-t-none border-t-0 focus:border-t"
           />
           {errors.password && errors.confirmPassword ? (
             <ErrorMessage message={errors.password.message} />

--- a/src/pages/auth/join02.tsx
+++ b/src/pages/auth/join02.tsx
@@ -23,8 +23,8 @@ export default function Join02() {
     watch,
   } = useForm();
 
-  const onSubmit = () => {
-    console.log(watch('id'));
+  const onSubmit = (form) => {
+    console.log(form);
   };
 
   return (
@@ -54,7 +54,7 @@ export default function Join02() {
             type="text"
             label="사용자 이름"
             placeholder="이름을 입력해주세요."
-            register={register('name', { required: true })}
+            register={register('username', { required: true })}
           />
           {errors.name && (
             <ErrorMessage message="최대 한글 25자 까지 입력 가능합니다." />
@@ -101,12 +101,16 @@ export default function Join02() {
           <Input
             type="text"
             label="휴대폰 번호"
-            placeholder="번호를 입력해주세요."
-            register={register('phoneNum', { required: true })}
+            placeholder="번호를 입력해주세요"
+            register={register('tel', {
+              required: true,
+              pattern: {
+                value: /^[0-9]{3}[0-9]{4}[0-9]{4}$/g,
+                message: '휴대폰번호를 정확히 입력해주세요.',
+              },
+            })}
           />
-          {errors.phoneNum && (
-            <ErrorMessage message="휴대폰번호를 정확히 입력해주세요." />
-          )}
+          {errors.tel && <ErrorMessage message={errors.tel.message} />}
         </section>
         <section className="mb-3">
           <Input

--- a/src/pages/auth/join02.tsx
+++ b/src/pages/auth/join02.tsx
@@ -130,7 +130,7 @@ export default function Join02() {
             register={register('tel', {
               required: true,
               pattern: {
-                value: /^[0-9]{3}[0-9]{4}[0-9]{4}$/g,
+                value: /^01([0|1|6|7|8|9])[0-9]{4}[0-9]{4}$/g,
                 message: '휴대폰번호를 정확히 입력해주세요.',
               },
             })}


### PR DESCRIPTION
## 🧑‍💻 PR 내용
userSlice에서 userState와 reducer를 정의하였습니다.
userInfo의 경우 객체로 전달하고 마케팅선택동의여부, 작가여부는 각각 전달합니다. 
회원가입시 휴대폰번호에 대해 reg validation을 적용했습니다.
회원가입시 공통항목 기입이 끝난경우 작가여부에 따라 auth/user/join01 또는 auth/author/join01로 라우팅합니다.

## 📸 스크린샷
features/user/userSlice.ts
<img width="236" alt="image" src="https://user-images.githubusercontent.com/92621861/209618067-85b69043-89e4-40f1-a516-ac5b03d2f2cc.png">
<img width="428" alt="image" src="https://user-images.githubusercontent.com/92621861/209618137-c6acb908-98e1-4455-aafd-fdeaf686d42c.png">
