### PR TITLE
react query 및 api 사용예시  

### DIFF
--- a/src/apis/README.md
+++ b/src/apis/README.md
@@ -1,0 +1,180 @@
+# apis 폴더 컨벤션
+
+네트워크 통신관련 api 가 정의 되어있는 폴더 입니다.
+기본적으로 스웨거의 태그를 기준으로 폴더가 만들어집니다
+
+폴더이름의 경우 소문자와 대쉬로 작성해주세요 ex)my-api
+
+## 폴더 구조
+
+apis
+
+```
+├── _axios
+├── example
+│ ├── exampleApi.ts :
+│ ├── exampleApi.query.ts
+│ ├── exampleApi.mutaion.ts
+│ └── exampleApi.type.ts
+├── type.d.ts
+└── README.md
+```
+
+## File Naming
+
+😀 파일명은 폴더명(태그명) + Api 에 종류별로 suffix 를 붙여 구분해줍니다. PascalCase 로 작성해주세요
+
+**apis/[folder-name]**
+
+- [FolderName]Api.ts:
+
+axios 를 사용하여 네트워크 통신을 처리하는 api 입니다.
+
+- [FolderName]Api.query.ts:
+
+Post.api.ts 에서 GET method 에 해당하는 함수를 React-Query 의 useQuery 으로 랩핑한 커스텀 훅의 집합입니다
+
+- [FolderName]Api.mutation.ts:
+
+Post.api.ts 에서 POST, PUT, PATCH , DELETE 요청에 해당하는 함수를 React-Query 의 useMutation 으로 랩핑한 커스텀 훅의 집합입니다
+
+- [FolderName]Api.type.ts:
+
+해당 api 경로에서 사용되는 데이터 타입의 집합입니다.
+
+## [FolderName]Api.ts
+
+😀 Api 들을 하나의 클래스로 추상화해주세요.
+
+나를 포함한 동료들이 코드를 찾기 쉬워집니다
+
+😀 Axios Instance 를 받아서 사용하게 끔 만들어 주세요
+
+instance 가 달라 질 수 있는 경우에 대응하기 쉬워집니다.
+
+😀 class mentod 의 네이밍은, request 의 method 네이밍을 preffix 로 붙여서 사용해주세요
+
+나를 포함한 동료들이 코드를 파악하기 쉬워집니다 ex) GET: getPost, PATCH: patchPost
+
+😀 class method 의 인자는 반드시 1개 이하 이어야 합니다. 2개 이상일시 객체로 넘겨주세요
+
+리액트 쿼리로 랩핑할때 class 의 Method 인자는 커스텀 타입정의에 의해 variables 라는 단일 값으로 관리가 되기 때문에 하나의 인자로 작성해주세요
+
+😀 class method 의 인자타입과 리턴타입을 반드시 명시 해주세요.
+
+코드를 파악하기 쉬워지고, 리액트 쿼리 훅 커스텀 타입이 인자와 리턴타입을 추출하여, 보다 정확한 타입을 제공할 수 있습니다.
+
+🧭 **Example**
+
+```tsx
+import { AxiosInstance } from 'axios';
+
+import instance from '@apis/_axios/instance';
+
+class PostApi {
+  constructor(private axios: AxiosInstance = instance) {
+    this.axios = axios;
+  }
+
+  async getPosts(parmas: SomePramType):SomeReturnType {
+    const { data } = await this.axios({
+      method: 'GET',
+      url: `/v1/posts`,
+      parmas,
+    });
+    return data;
+  }
+
+  async createPost(body: SomeBodyType):SomeReturnType {
+    const { data } = await this.axios({
+      method: 'POST',
+      url: `/v1/posts`,
+      data: body,
+    });
+    return data;
+  }
+
+  ...
+}
+
+const postApi = new PostApi();
+
+export default postApi;
+```
+
+## [FolderName]Api.query.ts
+
+😀 미리 정의 된 QueryHookParams 를 통해 인자 타입을 정의해 주세요
+
+😀 QUERY_KEY 라는 constants 로 관리되는 쿼리 키를 통해, 쿼리키를 관리해주세요
+
+😀 네이밍은 use[targetMethod]Query 형태로 만들어주세요
+
+😀 쿼리키는 배열을 리턴하는 함수로 만들어서, params 에 대응하게끔 관리해주세요
+
+🧭 **Example**
+
+```tsx
+import { useQuery } from 'react-query';
+import postApi from './PostApi.ts';
+import { QueryHookParams } from 'apis/type';
+import { QUERY_KEY } from 'constants/query-keys';
+export const useGetPostsQuery = (
+  params: QueryHookParams<typeof postApi.getPosts>,
+) => {
+  return useQuery(
+    QUERY_KEY.POST.GET(params?.variables),
+    () => postApi.getPosts(params?.variables),
+    params?.options,
+  );
+};
+```
+
+## [FolderName]Api.query.ts
+
+😀 미리 정의 된 MutationHookParams 를 통해 인자 타입을 정의해 주세요
+
+😀 QUERY_KEY 는 많은 경우에서 사용되지 않지만 필요한 경우 query 와 같이 QUERY_KEY 로 관리되는 값으로 사용해주세요
+
+😀 네이밍은 use[targetMethod]Mutation 형태로 만들어주세요
+
+🧭 **Example**
+
+```tsx
+import { useMutation } from 'react-query';
+import postApi from './PostApi.ts';
+import { MutationHookParams } from 'apis/type';
+export const useDeletePostMutation = (
+  params?: MutationHookParams<typeof postApi.deletePost>,
+) => {
+  return useMutation(postApi.deletePost, { ...params?.options });
+};
+```
+
+## [FolderName]Api.type.ts
+
+Api 에 대한 타입정의를 [FolderName]Api.ts 에서 분리하고 싶을경우 분리해주세요
+
+😀 타입 정의시 field 별로 /\*_ ... _/ 형태로 주석을 달아주세요
+
+나 혹은 동료가 값에 대한 정의를 보기 위해 스웨거에 들어갈 일이 적어집니다. js-doc 문법으로써, vscode 에디터를 쓰고 있다면 해당 field 가 사용되는 곳에서 hover 시 바로 주석을 볼수 있습니다.
+
+```tsx
+type BuildingDataType = {
+...
+  /** 도로명주소  */
+  addressLoad: string;
+  /** 건물관리번호  */
+  building?: string;
+  /** 대지위치 */
+  platPlc?: string;
+  /** 대지면적(㎡) */
+  platArea?: number;
+  /** 대지면적(평) */
+  platAreaP?: number;
+  /** 지구지역 */
+  jiyukCdNm?: string;
+...
+}
+
+```

--- a/src/apis/_axios/instance.ts
+++ b/src/apis/_axios/instance.ts
@@ -20,7 +20,7 @@ const refreshToken = async () => {
   const refresh = getToken().refresh;
   // refresh token api 호출
   const token = await instance
-    .post('/v1/users/token/refresh', {
+    .post('/members/token', {
       refresh: refresh,
     })
     .then((res) => res.data);

--- a/src/apis/example/exampleApi.mutaton.ts
+++ b/src/apis/example/exampleApi.mutaton.ts
@@ -1,0 +1,47 @@
+import { useMutation } from 'react-query';
+
+import { MutationHookParams } from '@apis/type';
+
+import exampleApi from './exampleApi';
+import {
+  ExampleDTOType,
+  ExampleParamPatchType,
+  ExampleParamPutType,
+} from './exampleApi.type';
+
+export const EXAMPLE_API_MUTATION_KEY = {
+  POST: (param: ExampleDTOType) => ['example-update', param],
+  PUT: (req: ExampleParamPutType) => ['example-put', req],
+  PATCH: (req: ExampleParamPatchType) => ['example-patch', req],
+  DELETE: (id: string) => ['example-delete', id],
+};
+
+export const usePostExampleMutation = (
+  params?: MutationHookParams<typeof exampleApi.postExample>,
+) => {
+  return useMutation(exampleApi.postExample, {
+    ...params?.options,
+  });
+};
+
+export const usePutExampleMutation = (
+  params?: MutationHookParams<typeof exampleApi.putExample>,
+) => {
+  return useMutation(exampleApi.putExample, {
+    ...params?.options,
+  });
+};
+export const usePatchExampleMutation = (
+  params?: MutationHookParams<typeof exampleApi.patchExample>,
+) => {
+  return useMutation(exampleApi.patchExample, {
+    ...params?.options,
+  });
+};
+export const useDeleteExampleMutation = (
+  params?: MutationHookParams<typeof exampleApi.deleteExample>,
+) => {
+  return useMutation(exampleApi.deleteExample, {
+    ...params?.options,
+  });
+};

--- a/src/apis/example/exampleApi.query.ts
+++ b/src/apis/example/exampleApi.query.ts
@@ -1,0 +1,36 @@
+import { useQuery } from 'react-query';
+
+import { QueryHookParams } from '@apis/type';
+
+import exampleApi from './exampleApi';
+import { ExampleParamGetType } from './exampleApi.type';
+
+export const EXAMPLE_API_QUERY_KEY = {
+  GET: (param: ExampleParamGetType) => ['example-list', param],
+  GET_BY_ID: (id: string) => ['example-by-id', id],
+};
+
+export function useGetListQuery(
+  params: QueryHookParams<typeof exampleApi.getExampleList>,
+) {
+  const queryKey = EXAMPLE_API_QUERY_KEY.GET(params.variables);
+  const query = useQuery(
+    queryKey,
+    () => exampleApi.getExampleList(params.variables),
+    params?.options,
+  );
+  return { ...query, queryKey };
+}
+
+export function useGetByIdQuery(
+  params: QueryHookParams<typeof exampleApi.getExampleById>,
+) {
+  const queryKey = EXAMPLE_API_QUERY_KEY.GET_BY_ID(params.variables);
+  const query = useQuery(
+    queryKey,
+    () => exampleApi.getExampleById(params.variables),
+    params?.options,
+  );
+
+  return { ...query, queryKey };
+}

--- a/src/apis/example/exampleApi.ts
+++ b/src/apis/example/exampleApi.ts
@@ -1,0 +1,73 @@
+import { AxiosInstance } from 'axios';
+
+import instance from '@apis/_axios/instance';
+
+import {
+  ExampleDTOType,
+  ExampleParamGetType,
+  ExampleParamPatchType,
+  ExampleParamPutType,
+} from './exampleApi.type';
+
+export class ExampleApi {
+  axios: AxiosInstance = instance;
+  constructor(axios?: AxiosInstance) {
+    if (axios) this.axios = axios;
+  }
+
+  async getExampleList(params: ExampleParamGetType): Promise<ExampleDTOType[]> {
+    const { data } = await this.axios({
+      method: 'GET',
+      url: `/posts`,
+      params,
+    });
+    return data;
+  }
+
+  async getExampleById(id: string): Promise<ExampleDTOType> {
+    const { data } = await this.axios({
+      method: 'GET',
+      url: `/example/${id}`,
+    });
+    return data;
+  }
+
+  async postExample(body: ExampleDTOType): Promise<ExampleDTOType> {
+    const { data } = await this.axios({
+      method: 'POST',
+      url: `/example`,
+      data: body,
+    });
+    return data;
+  }
+
+  async putExample(req: ExampleParamPutType): Promise<ExampleDTOType> {
+    const { data } = await this.axios({
+      method: 'PUT',
+      url: `/example/${req.id}`,
+      data: req.data,
+    });
+    return data;
+  }
+
+  async patchExample(req: ExampleParamPatchType): Promise<ExampleDTOType> {
+    const { data } = await this.axios({
+      method: 'PATCH',
+      url: `/example/${req.id}`,
+      data: req.data,
+    });
+    return data;
+  }
+
+  async deleteExample(id: string): Promise<boolean> {
+    const { data } = await this.axios({
+      method: 'DELETE',
+      url: `/example/${id}`,
+    });
+    return data;
+  }
+}
+
+const exampleApi = new ExampleApi();
+
+export default exampleApi;

--- a/src/apis/example/exampleApi.type.ts
+++ b/src/apis/example/exampleApi.type.ts
@@ -1,0 +1,10 @@
+export type ExampleDTOType = {};
+export type ExampleParamGetType = {};
+export type ExampleParamPutType = {
+  id: string;
+  data: ExampleDTOType;
+};
+export type ExampleParamPatchType = {
+  id: string;
+  data: Partial<ExampleDTOType>;
+};

--- a/src/apis/type.d.ts
+++ b/src/apis/type.d.ts
@@ -1,0 +1,58 @@
+import {
+  UseInfiniteQueryOptions,
+  UseMutationOptions,
+  UseQueryOptions,
+} from 'react-query';
+
+import { AxiosError } from 'axios';
+
+export type QueryHookParams<
+  T extends CustomRequestFn,
+  Data = RequestFnReturn<T>,
+  Variables = Parameter<T>,
+  Error = MyError,
+> = {
+  options?: Omit<UseQueryOptions<Data, Error>, 'queryKey' | 'queryFn'>;
+} & OptionalVariables<Variables>;
+
+export type InfiniteQueryHookParams<
+  T extends CustomRequestFn,
+  Data = RequestFnReturn<T>,
+  Variables = Parameter<T>,
+  Error = MyError,
+> = {
+  options?: Omit<
+    UseInfiniteQueryOptions<Data, Error, Data, Data, any>,
+    'queryKey' | 'queryFn'
+  >;
+} & OptionalVariables<Variables>;
+
+export type MutationHookParams<
+  T extends CustomRequestFn,
+  Data = RequestFnReturn<T>,
+  Variables = Parameter<T>,
+  Error = MyError,
+> = {
+  options?: Omit<
+    UseMutationOptions<Data, Error, Variables>,
+    'mutationFn' | 'mutationKey'
+  >;
+};
+
+export type CustomRequestFn = (variables?: any) => Promise<any>;
+
+export type RequestFnReturn<T extends CustomRequestFn> = UnboxPromise<
+  ReturnType<T>
+>;
+
+export type OptionalVariables<T> = undefined extends T
+  ? { variables?: T }
+  : { variables: T };
+
+export type UnboxPromise<T extends Promise<any>> = T extends Promise<infer U>
+  ? U
+  : never;
+
+export type Parameter<T> = T extends (param: infer U) => any ? U : never;
+
+export type MyError = AxiosError;

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,19 +1,23 @@
 import type { AppProps } from 'next/app';
 import '../styles/globals.css';
 import { Provider } from 'react-redux';
-import store from '../features/store';
+import store from '@features/store';
 import { PersistGate } from 'redux-persist/integration/react';
 import { persistStore } from 'redux-persist';
+import { QueryClient, QueryClientProvider } from 'react-query';
 
+const queryClient = new QueryClient();
 const persistor = persistStore(store);
 
 export default function App({ Component, pageProps }: AppProps) {
   return (
     <div className="mx-auto w-full max-w-[375px]">
       <Provider store={store}>
-        <PersistGate loading={null} persistor={persistor}>
-          <Component {...pageProps} />
-        </PersistGate>
+        <QueryClientProvider client={queryClient}>
+          <PersistGate loading={null} persistor={persistor}>
+            <Component {...pageProps} />
+          </PersistGate>
+        </QueryClientProvider>
       </Provider>
     </div>
   );


### PR DESCRIPTION
## 🧑‍💻 PR 내용
├── _axios : axios intance 설정 및 토큰 로직
├── example : API tag
│ ├── exampleApi.ts : crud api들을 하나의 class로 추상화 합니다. 
│ ├── exampleApi.query.ts : 위에서 추상화한 api들을 react-query useQuery로 맵핑합니다.
│ ├── exampleApi.mutaion.ts : 위에서 추상화한 api들을 react-query useMutaion로 맵핑합니다.
│ └── exampleApi.type.ts : 필요한 경우 추가로 type을 정의할 수 있습니다. 
├── type.d.ts 
└── README.md

좀 더 자세한 내용은 리드미를 확인해주시면 되겠습니다. 

## 📸 스크린샷

<img width="159" alt="image" src="https://user-images.githubusercontent.com/92621861/209897425-44ef8a0e-ec90-4d17-9033-99a75c769cf3.png">