### PR TITLE
rtk 필드 변수명 수정 & 공통 회원가입 2번 페이지 폼 변수명 수정

### DIFF
--- a/src/features/user/userSlice.ts
+++ b/src/features/user/userSlice.ts
@@ -1,11 +1,11 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
 type userInfo = {
-  id: string;
+  userId: string;
   password: string;
   email: string;
   username: string;
-  tel: string;
+  telephone: string;
 };
 interface userState extends userInfo {
   tastes: string[];
@@ -14,11 +14,11 @@ interface userState extends userInfo {
 }
 
 const initialState: userState = {
-  id: '',
+  userId: '',
   password: '',
   email: '',
   username: '',
-  tel: '',
+  telephone: '',
   tastes: [],
   isApprovePromotion: false,
   isArtist: false,
@@ -30,11 +30,11 @@ const userSlice = createSlice({
   reducers: {
     setUserInfo: (state: userState, action: PayloadAction<userInfo>) => ({
       ...state,
-      id: action.payload.id,
+      id: action.payload.userId,
       password: action.payload.password,
       email: action.payload.email,
       username: action.payload.username,
-      tel: action.payload.tel,
+      tel: action.payload.telephone,
     }),
     setTastes: (state: userState, action: PayloadAction<string[]>) => ({
       ...state,

--- a/src/pages/auth/join02.tsx
+++ b/src/pages/auth/join02.tsx
@@ -9,11 +9,11 @@ import { useRouter } from 'next/router';
 import { useAppDispatch, useAppSelector } from '@features/hooks';
 import { setUserInfo } from '@features/user/userSlice';
 interface JoinForm {
-  id: string;
+  userId: string;
   username: string;
   password: string;
   confirmPassword: string;
-  tel: string;
+  telephone: string;
   email: string;
 }
 
@@ -37,13 +37,13 @@ export default function Join02() {
   } = useForm<JoinForm>();
 
   const onSubmit = (form: JoinForm) => {
-    const { id, username, password, tel, email } = form;
+    const { userId, username, password, telephone, email } = form;
     dispatch(
       setUserInfo({
-        id,
+        userId,
         username,
         password,
-        tel,
+        telephone,
         email,
       }),
     );
@@ -70,9 +70,11 @@ export default function Join02() {
             type="text"
             label="ID"
             placeholder="아이디를 입력해주세요."
-            register={register('id', { required: true })}
+            register={register('userId', { required: true })}
           />
-          {errors.id && <ErrorMessage message="이미 사용중인 아이디입니다." />}
+          {errors.userId && (
+            <ErrorMessage message="이미 사용중인 아이디입니다." />
+          )}
         </section>
         <section className="mb-3">
           <Input
@@ -128,7 +130,7 @@ export default function Join02() {
             type="text"
             label="휴대폰 번호"
             placeholder="번호를 입력해주세요"
-            register={register('tel', {
+            register={register('telephone', {
               required: true,
               pattern: {
                 value: /^01([0|1|6|7|8|9])[0-9]{4}[0-9]{4}$/g,
@@ -136,7 +138,9 @@ export default function Join02() {
               },
             })}
           />
-          {errors.tel && <ErrorMessage message={errors.tel.message} />}
+          {errors.telephone && (
+            <ErrorMessage message={errors.telephone.message} />
+          )}
         </section>
         <section className="mb-3">
           <Input


### PR DESCRIPTION
## 🧑‍💻 PR 내용

rtk userSlice의 변수명을 API 명세서와 같게 수정하였습니다.
userSlice 수정사항을 반영하여 공통 회원가입 react hook form의 폼 변수명도 수정하였습니다.

## 📸 스크린샷

![image](https://user-images.githubusercontent.com/79186378/210191254-af1084c2-ebe1-4967-991f-7c81b40d5100.png)
![image](https://user-images.githubusercontent.com/79186378/210191255-d8e88446-f842-4fad-a6e0-d1cac72eb3f4.png)

