### PR TITLE
카카오 네이버 소셜 로그인 구현

### DIFF
--- a/src/features/user/userSlice.ts
+++ b/src/features/user/userSlice.ts
@@ -9,13 +9,11 @@ type userInfo = {
 };
 interface userState extends userInfo {
   tastes: string[]; //user
-
   education: string; //artist
   history: string;
   description: string;
   instagram: string;
   behance: string;
-
   isApprovePromotion: boolean;
   isArtist: boolean;
 }
@@ -55,7 +53,7 @@ const userSlice = createSlice({
       ...state,
       tastes: action.payload,
     }),
-    setArtistInfo: (state: userState, action: PayloadAction<string>) => ({
+    setArtistInfo: (state: userState, action: PayloadAction<userState>) => ({
       ...state,
       education: action.payload.education,
       history: action.payload.history,

--- a/src/pages/auth/kakao/callback.tsx
+++ b/src/pages/auth/kakao/callback.tsx
@@ -7,20 +7,19 @@ import { Token } from '@utils/localStorage/token';
 export default function Callback() {
   useEffect(() => {
     const code = new URL(window.location.href).searchParams.get('code');
-    // kakao login with code and if token save token at localStorage
-    // instance
-    //   .post('/auth/kakao', { code })
-    //   .then((res) => {
-    //     const token: Token = {
-    //       access: res.data.accessToken,
-    //       refresh: res.data.refreshToken,
-    //       isRegister: res.data.isRegister,
-    //     };
-    //     if (token) setToken(token);
-    //   })
-    //   .catch((err) => {
-    //     console.log(err);
-    //   });
+    instance
+      .get(`/oauth2/kakao?code=${code}`)
+      .then((res) => {
+        console.log(res.data);
+        const token: Token = {
+          access: res.data.accessToken,
+          refresh: res.data.refreshToken,
+        };
+        if (token) setToken(token);
+      })
+      .catch((err) => {
+        console.log(err);
+      });
   }, []);
 
   return (

--- a/src/pages/auth/kakao/callback.tsx
+++ b/src/pages/auth/kakao/callback.tsx
@@ -3,8 +3,11 @@ import { useEffect } from 'react';
 import instance from '@apis/_axios/instance';
 import { setToken } from '@utils/localStorage/token';
 import { Token } from '@utils/localStorage/token';
+import { useRouter } from 'next/router';
 
-export default function Callback() {
+export default function KakaoCallback() {
+  const router = useRouter();
+
   useEffect(() => {
     const code = new URL(window.location.href).searchParams.get('code');
     instance
@@ -17,6 +20,7 @@ export default function Callback() {
         };
         if (token) setToken(token);
       })
+      .then(() => router.push('/home'))
       .catch((err) => {
         console.log(err);
       });

--- a/src/pages/auth/login.tsx
+++ b/src/pages/auth/login.tsx
@@ -53,15 +53,17 @@ function Login() {
               />
               <span className="ml-[10px]">네이버</span>
             </div>
-            <div className="flex justify-center items-center">
-              <Image
-                src="/svg/social/kakao_logo.svg"
-                alt="kakao"
-                width={18}
-                height={18}
-              />
-              <span className="ml-[10px]">카카오톡</span>
-            </div>
+            <Link href="https://kauth.kakao.com/oauth/authorize?client_id=b5b9faf3a6925894eef87a665c2cb072&redirect_uri=http://localhost:3000/auth/kakao/callback&response_type=code">
+              <div className="flex justify-center items-center">
+                <Image
+                  src="/svg/social/kakao_logo.svg"
+                  alt="kakao"
+                  width={18}
+                  height={18}
+                />
+                <span className="ml-[10px]">카카오톡</span>
+              </div>
+            </Link>
           </div>
           <p className="w-full text-center text-12 mt-[29px]">
             계정을 잊으셨나요?&nbsp;

--- a/src/pages/auth/login.tsx
+++ b/src/pages/auth/login.tsx
@@ -5,6 +5,20 @@ import Link from 'next/link';
 import Image from 'next/image';
 import { useForm } from 'react-hook-form';
 import Button from '@components/common/Button';
+import { CONFIG } from '@config';
+
+const randomString = (length: number) => {
+  let result = '';
+  const characters =
+    'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+  const charactersLength = characters.length;
+  for (let i = 0; i < length; i++) {
+    result += characters.charAt(Math.floor(Math.random() * charactersLength));
+  }
+  return result;
+};
+
+const STATESTRING = randomString(20);
 
 function Login() {
   const {
@@ -44,16 +58,22 @@ function Login() {
             <Button text="로그인" />
           </div>
           <div className="flex justify-around items-center mt-[29px] text-12">
-            <div className="flex justify-center items-center">
-              <Image
-                src="/svg/social/naver_logo.svg"
-                alt="kakao"
-                width={18}
-                height={18}
-              />
-              <span className="ml-[10px]">네이버</span>
-            </div>
-            <Link href="https://kauth.kakao.com/oauth/authorize?client_id=b5b9faf3a6925894eef87a665c2cb072&redirect_uri=http://localhost:3000/auth/kakao/callback&response_type=code">
+            <Link
+              href={`https://nid.naver.com/oauth2.0/authorize?response_type=code&client_id=${CONFIG.API_KEYS.NAVER}&state=${STATESTRING}&redirect_uri=http://localhost:3000/auth/naver/callback`}
+            >
+              <div className="flex justify-center items-center">
+                <Image
+                  src="/svg/social/naver_logo.svg"
+                  alt="kakao"
+                  width={18}
+                  height={18}
+                />
+                <span className="ml-[10px]">네이버</span>
+              </div>
+            </Link>
+            <Link
+              href={`https://kauth.kakao.com/oauth/authorize?client_id=${CONFIG.API_KEYS.KAKAO}&redirect_uri=http://localhost:3000/auth/kakao/callback&response_type=code`}
+            >
               <div className="flex justify-center items-center">
                 <Image
                   src="/svg/social/kakao_logo.svg"

--- a/src/pages/auth/naver/callback.tsx
+++ b/src/pages/auth/naver/callback.tsx
@@ -3,12 +3,14 @@ import { useEffect } from 'react';
 import instance from '@apis/_axios/instance';
 import { setToken } from '@utils/localStorage/token';
 import { Token } from '@utils/localStorage/token';
+import { useRouter } from 'next/router';
 
-export default function Callback() {
+export default function NaverCallback() {
+  const router = useRouter();
+
   useEffect(() => {
     const code = new URL(window.location.href).searchParams.get('code');
     const state = new URL(window.location.href).searchParams.get('state');
-
     instance
       .get(`/oauth2/naver?code=${code}&state=${state}`)
       .then((res) => {
@@ -18,6 +20,7 @@ export default function Callback() {
         };
         if (token) setToken(token);
       })
+      .then(() => router.push('/home'))
       .catch((err) => {
         console.log(err);
       });

--- a/src/pages/auth/naver/callback.tsx
+++ b/src/pages/auth/naver/callback.tsx
@@ -1,0 +1,39 @@
+import Layout from '@components/common/Layout';
+import { useEffect } from 'react';
+import instance from '@apis/_axios/instance';
+import { setToken } from '@utils/localStorage/token';
+import { Token } from '@utils/localStorage/token';
+
+export default function Callback() {
+  useEffect(() => {
+    const code = new URL(window.location.href).searchParams.get('code');
+    const state = new URL(window.location.href).searchParams.get('state');
+
+    instance
+      .get(`/oauth2/naver?code=${code}&state=${state}`)
+      .then((res) => {
+        const token: Token = {
+          access: res.data.accessToken,
+          refresh: res.data.refreshToken,
+        };
+        if (token) setToken(token);
+      })
+      .catch((err) => {
+        console.log(err);
+      });
+  }, []);
+
+  return (
+    <Layout>
+      <div className="flex justify-center items-center h-screen">
+        <div className="grid gap-2">
+          <div className="flex items-center justify-center space-x-2">
+            <div className="w-3 h-3 bg-[#F5535D] rounded-full animate-bounce1"></div>
+            <div className="w-3 h-3 bg-[#F5535D] rounded-full animate-bounce2"></div>
+            <div className="w-3 h-3 bg-[#F5535D] rounded-full animate-bounce3"></div>
+          </div>
+        </div>
+      </div>
+    </Layout>
+  );
+}

--- a/src/utils/localStorage/token/index.ts
+++ b/src/utils/localStorage/token/index.ts
@@ -10,13 +10,11 @@ const TOKEN_KEY = CONFIG.AUTH_TOKEN_KEY || '@token';
 export type Token = {
   access: string | null;
   refresh: string | null;
-  isRegister: boolean;
 };
 
 export const getToken = () => {
   const token = getLocalStorage<Token>(TOKEN_KEY, {
     access: null,
-    isRegister: false,
     refresh: null,
   });
   return token;


### PR DESCRIPTION
## 🧑‍💻 PR 내용
소셜 로그인 로직은 다음과 같습니다.
(1) auth/login, 소셜 로그인 버튼을 눌러서 카카오에 인가코드 발급 요청 auth/kakao/callback로 redirect
(2) 인가코드를 가지고 서버로 토큰 발급 요청 서버는 카카오에 토큰 발급 요청한뒤 받은 토큰을 가지고 사용자정보를 DB에 저장 이후 자체 jwt 토큰을 발급하여 클라이언트로 전송
(3) 서버로부터 받은 토큰(access, refresh)을 사용자의 로컬스토리지에 저장

인가코드 발급, 토큰 발급 두번의 요청에서 카카오의 경우 redirectURL, 네이버의 경우 STATESTRING(프론트에서 생성한 임의 변수)를 가지고 동일성 검사를 합니다. 

일단은 소셜로그인 완료시 /home으로 이동하도록 해두었습니다.
## 📸 스크린샷

![image](https://user-images.githubusercontent.com/92621861/210302039-93822689-a92f-4b7a-b8c8-c2ecb252f6da.png)