### PR TITLE
로컬 회원가입 구현

### DIFF
--- a/src/apis/auth/authApi.ts
+++ b/src/apis/auth/authApi.ts
@@ -2,7 +2,7 @@ import { AxiosInstance } from 'axios';
 
 import instance from '@apis/_axios/instance';
 
-import { AuthDTOType } from './authApi.type';
+import { AuthDTOType, DoubleCheckDTOType } from './authApi.type';
 
 export class AuthApi {
   axios: AxiosInstance = instance;
@@ -46,7 +46,7 @@ export class AuthApi {
     return data;
   }
 
-  async postNesPassword(body: AuthDTOType): Promise<AuthDTOType> {
+  async postNewPassword(body: AuthDTOType): Promise<AuthDTOType> {
     const { data } = await this.axios({
       method: 'POST',
       url: `/members/new-password`,
@@ -63,20 +63,18 @@ export class AuthApi {
     return data;
   }
 
-  async postCheckEmail(body: AuthDTOType): Promise<AuthDTOType> {
+  async getCheckEmail(email): Promise<DoubleCheckDTOType> {
     const { data } = await this.axios({
-      method: 'POST',
-      url: `/members/check-email`,
-      data: body,
+      method: 'GET',
+      url: `/members/check-email?email=${email}`,
     });
     return data;
   }
 
-  async postChcekId(body: AuthDTOType): Promise<AuthDTOType> {
+  async getCheckId(userId): Promise<DoubleCheckDTOType> {
     const { data } = await this.axios({
-      method: 'POST',
-      url: `/members/check-id`,
-      data: body,
+      method: 'GET',
+      url: `/members/check-id?userId=${userId}`,
     });
     return data;
   }

--- a/src/apis/auth/authApi.type.ts
+++ b/src/apis/auth/authApi.type.ts
@@ -8,3 +8,6 @@ export type AuthParamPatchType = {
   id: string;
   data: Partial<AuthDTOType>;
 };
+export type DoubleCheckDTOType = {
+  duplicate: boolean;
+};

--- a/src/components/common/DoubleCheckButton.tsx
+++ b/src/components/common/DoubleCheckButton.tsx
@@ -1,0 +1,24 @@
+import tw from 'tailwind-styled-components';
+
+interface buttonProps {
+  text: string;
+  $valid?: boolean;
+  onClick?: () => void;
+  [key: string]: any;
+}
+
+const DoubleCheckButton = tw.button<buttonProps>`
+w-[58px] h-[25px] text-[12px] radius border-[1px] rounded flex justify-center ${(
+  p,
+) => (p.$valid ? 'border-[#DBDBDB]' : 'border-[#0099FF]')}
+  ${(p) => (p.$valid ? 'text-[#767676]' : 'text-[#0099FF]')}
+  items-center absolute right-[8px] top-[45px] cursor-pointer font-bold
+`;
+
+export default function Button({ text, onClick, ...rest }: buttonProps) {
+  return (
+    <DoubleCheckButton onClick={onClick} {...rest}>
+      {text}
+    </DoubleCheckButton>
+  );
+}

--- a/src/components/common/Input.tsx
+++ b/src/components/common/Input.tsx
@@ -5,6 +5,7 @@ interface InputProps {
   type: string;
   label?: string;
   placeholder?: string;
+  $error?: boolean;
   register?: UseFormRegisterReturn;
   [key: string]: any;
 }
@@ -21,7 +22,8 @@ text-14 leading-8
 `;
 
 const InputTag = tw.input<InputProps>`
-w-full h-[52px] placeholder-[#999999] text-[13px] rounded-[4px] border-[#D8D8D8] appearance-none
+w-full h-[52px] placeholder-[#999999] text-[13px] rounded-[4px] ${(p) =>
+  p.$error ? 'border-[#FF3120]' : 'border-[#D8D8D8]'} appearance-none
 `;
 
 export default function Input({

--- a/src/pages/auth/join02.tsx
+++ b/src/pages/auth/join02.tsx
@@ -219,7 +219,7 @@ export default function Join02() {
           <Input
             type="email"
             label="이메일"
-            placeholder="이메일을 입력해주세요."
+            placeholder="ATTIES@naver.com"
             $error={errors.email ? true : false}
             register={register('email', {
               required: true,

--- a/src/pages/auth/join02.tsx
+++ b/src/pages/auth/join02.tsx
@@ -42,7 +42,7 @@ export default function Join02() {
     watch,
     setError,
     clearErrors,
-  } = useForm<JoinForm>({ mode: 'onChange' });
+  } = useForm<JoinForm>({ mode: 'onTouched' });
 
   const onSubmit = async (form: JoinForm) => {
     const { userId, username, password, telephone, email } = form;

--- a/src/pages/auth/join02.tsx
+++ b/src/pages/auth/join02.tsx
@@ -5,9 +5,12 @@ import Input from '@components/common/Input';
 import Button from '@components/common/Button';
 import Navigate from '@components/common/Navigate';
 import ErrorMessage from '@components/common/ErrorMessage';
+import DoubleCheckButton from '@components/common/DoubleCheckButton';
 import { useRouter } from 'next/router';
 import { useAppDispatch, useAppSelector } from '@features/hooks';
 import { setUserInfo } from '@features/user/userSlice';
+import authApi from '@apis/auth/authApi';
+
 interface JoinForm {
   userId: string;
   username: string;
@@ -18,6 +21,9 @@ interface JoinForm {
 }
 
 export default function Join02() {
+  const [emailValidation, setEmailValidation] = useState<boolean>(false);
+  const [idValidation, setIdValidation] = useState<boolean>(false);
+
   const router = useRouter();
   const handleLeftButton = () => {
     router.push('/auth/join01');
@@ -25,40 +31,31 @@ export default function Join02() {
   const handleRightButton = () => {
     router.push('/auth/login');
   };
+
   const dispatch = useAppDispatch();
   const userState = useAppSelector((state) => state.user);
-  const [isDoubleChecked, setIsDoubleChecked] = useState([]);
-
+  // console.log(userState.isArtist);
   const {
     register,
     handleSubmit,
     formState: { errors },
+    watch,
     setError,
     clearErrors,
-  } = useForm<JoinForm>();
-  console.log(errors);
-  const onSubmit = (form: JoinForm) => {
-    const { userId, username, password, confirmPassword, telephone, email } =
-      form;
-    // 비밀번호 불일치 시
-    if (password !== confirmPassword) {
-      setError('confirmPassword', {
-        message: '비밀번호가 일치하지 않습니다.',
-      });
-      return;
-    }
-    // userId 중복확인 미확인시
-    if (!isDoubleChecked.includes('userId')) {
+  } = useForm<JoinForm>({ mode: 'onChange' });
+
+  const onSubmit = async (form: JoinForm) => {
+    const { userId, username, password, telephone, email } = form;
+    if (!idValidation) {
       setError('userId', {
-        message: '아이디 중복확인을 해주세요',
+        type: 'id doublecheck',
+        message: '아이디 중복확인을 해주세요.',
       });
       return;
-    }
-    // email 중복확인 미확인시
-    console.log(isDoubleChecked);
-    if (!isDoubleChecked.includes('email')) {
+    } else if (!emailValidation) {
       setError('email', {
-        message: '이메일 중복확인을 해주세요',
+        type: 'email doublecheck',
+        message: '이메일 중복확인을 해주세요.',
       });
       return;
     }
@@ -71,51 +68,40 @@ export default function Join02() {
         email,
       }),
     );
-
     if (userState.isArtist) router.push('/auth/artist/join01');
     else router.push('/auth/user/join01');
   };
-  const handleDoubleCheckID = () => {
-    // userId 중복확인 API
-    if (false) {
-      // userId 중복 시
+
+  const handleDoubleCheckID = async () => {
+    const data = await authApi.getCheckId(watch('userId'));
+    console.log('ID 중복이면 true 아니면 false : ', data.duplicate);
+    if (data.duplicate) {
       setError('userId', {
-        message: '이미 사용 중인 아이디입니다.',
+        type: 'id duplicate',
+        message: '이미 사용중인 아이디 입니다.',
       });
-    } else {
+      return;
+    } else if (!data.duplicate) {
+      setIdValidation(true);
       clearErrors('userId');
-      if (isDoubleChecked.includes('userId')) {
-        setIsDoubleChecked(
-          isDoubleChecked.filter((it: string) => it != 'userId'),
-        );
-      } else {
-        setIsDoubleChecked([...isDoubleChecked, 'userId']);
-      }
     }
   };
-  const handleDoubleCheckEmail = () => {
-    // Email 중복확인 API
-    if (false) {
-      // Email 중복 시
-      setError(
-        'email',
-        {
-          type: 'email using',
-          message: '이미 사용 중인 이메일입니다.',
-        },
-        { shouldFocus: true },
-      );
-    } else {
+
+  const handleDoubleCheckEmail = async () => {
+    const data = await authApi.getCheckEmail(watch('email'));
+    console.log('Email 중복이면 true 아니면 false : ', data.duplicate);
+    if (data.duplicate) {
+      setError('email', {
+        type: 'email duplicate',
+        message: '이미 가입된 이메일 입니다.',
+      });
+      return;
+    } else if (!data.duplicate) {
+      setEmailValidation(true);
       clearErrors('email');
-      if (isDoubleChecked.includes('email')) {
-        setIsDoubleChecked(
-          isDoubleChecked.filter((it: string) => it != 'email'),
-        );
-      } else {
-        setIsDoubleChecked([...isDoubleChecked, 'email']);
-      }
     }
   };
+
   return (
     <Layout>
       <Navigate
@@ -129,11 +115,13 @@ export default function Join02() {
         </p>
       </section>
       <form autoComplete="off" onSubmit={handleSubmit(onSubmit)}>
+        {/* 유저 아이디 */}
         <section className="mb-3 relative">
           <Input
             type="text"
             label="ID"
             placeholder="영문+숫자 조합 5자리 이상 입력해주세요."
+            $error={errors.userId ? true : false}
             register={register('userId', {
               required: true,
               pattern: {
@@ -141,25 +129,22 @@ export default function Join02() {
                 message: '아이디 형식에 맞게 입력해주세요.',
               },
             })}
-            defaultValue="abcd1234" //테스트를 위한 코드
+          />
+          <DoubleCheckButton
+            $valid={!idValidation}
+            onClick={handleDoubleCheckID}
+            text={idValidation ? '사용가능' : '중복확인'}
           />
           {errors.userId && <ErrorMessage message={errors.userId.message} />}
-          <div
-            className={`w-[58px] h-[25px] border ${
-              isDoubleChecked.includes('userId')
-                ? 'text-[#FF3120] border-[#FF3120]'
-                : 'text-[#767676] border[#767676]'
-            } text-12 rounded flex justify-centeritems-center absolute right-[8px] top-[45px] cursor-pointer font-bold justify-center items-center`}
-            onClick={handleDoubleCheckID}
-          >
-            중복확인
-          </div>
         </section>
+
+        {/* 유저이름 */}
         <section className="mb-3 relative">
           <Input
             type="text"
             label="사용자 이름"
             placeholder="이름을 입력해주세요."
+            $error={errors.username ? true : false}
             register={register('username', {
               required: true,
               pattern: {
@@ -167,17 +152,19 @@ export default function Join02() {
                 message: '최대 한글25자까지 입력 가능합니다.',
               },
             })}
-            defaultValue="박규성" //테스트를 위한 코드
           />
           {errors.username && (
             <ErrorMessage message={errors.username.message} />
           )}
         </section>
+
+        {/* 비밀번호 */}
         <section className="mb-3">
           <Input
             type="password"
             label="비밀번호"
             placeholder="영문+숫자 조합 8자리 이상 입력해주세요."
+            $error={errors.password ? true : false}
             register={register('password', {
               required: true,
               pattern: {
@@ -185,34 +172,35 @@ export default function Join02() {
                 message: '비밀번호를 형식에 맞게 입력해주세요.',
               },
             })}
-            className="rounded-b-none focus:translate-y-[-1px]"
-            defaultValue="abcd1234" //테스트를 위한 코드
+            className="mb-0"
+          />
+          <Input
+            type="password"
+            placeholder="비밀번호 재입력"
+            $error={errors.confirmPassword ? true : false}
+            register={register('confirmPassword', {
+              required: true,
+              validate: (value: string) => {
+                if (watch('password') !== value)
+                  return '비밀번호가 일치하지 않습니다.';
+              },
+            })}
           />
           {errors.password && (
             <ErrorMessage message={errors.password.message} />
           )}
-          <Input
-            type="password"
-            placeholder="비밀번호 재입력"
-            register={register('confirmPassword', {
-              required: true,
-              pattern: {
-                value: /^[A-Za-z0-9]{8,15}$/,
-                message: '비밀번호를 형식에 맞게 입력해주세요.',
-              },
-            })}
-            className="rounded-t-none  focus:border-t "
-            defaultValue="abcd1234" //테스트를 위한 코드
-          />
-          {errors.confirmPassword && (
+          {errors.confirmPassword && !errors.password && (
             <ErrorMessage message={errors.confirmPassword.message} />
           )}
         </section>
+
+        {/* 휴대폰 번호 */}
         <section className="mb-3">
           <Input
             type="text"
             label="휴대폰 번호"
             placeholder="-를 제외하고 입력해주세요."
+            $error={errors.telephone ? true : false}
             register={register('telephone', {
               required: true,
               pattern: {
@@ -220,17 +208,19 @@ export default function Join02() {
                 message: '휴대폰번호를 정확히 입력해주세요.',
               },
             })}
-            defaultValue="01012345678" //테스트를 위한 코드
           />
           {errors.telephone && (
             <ErrorMessage message={errors.telephone.message} />
           )}
         </section>
+
+        {/* 이메일 */}
         <section className="mb-3 relative">
           <Input
             type="email"
             label="이메일"
-            placeholder="ATTIES@naver.com"
+            placeholder="이메일을 입력해주세요."
+            $error={errors.email ? true : false}
             register={register('email', {
               required: true,
               pattern: {
@@ -238,22 +228,17 @@ export default function Join02() {
                 message: '이메일 형식이 올바르지 않습니다.',
               },
             })}
-            defaultValue="gueit214@naver.com" //테스트를 위한 코드
           />
           {errors.email && errors.email.message && (
             <ErrorMessage message={errors.email.message} />
-          )}
-          <div
-            className={`w-[58px] h-[25px] border ${
-              isDoubleChecked.includes('email')
-                ? 'text-[#FF3120] border-[#FF3120]'
-                : 'text-[#767676] border[#767676]'
-            } text-12 rounded flex justify-centeritems-center absolute right-[8px] top-[45px] cursor-pointer font-bold justify-center items-center`}
+          )}{' '}
+          <DoubleCheckButton
+            $valid={!emailValidation}
             onClick={handleDoubleCheckEmail}
-          >
-            중복확인
-          </div>
+            text={emailValidation ? '사용가능' : '중복확인'}
+          />
         </section>
+
         <div className="h-[30px]" />
         <section>
           <Button text="확인" type="submit" />


### PR DESCRIPTION
## 🧑‍💻 PR 내용

로컬 회원가입에서 react-hook-form의 모드를 onChange로 변경하여 onSubmit이 최초에 일어나지 않아도 에러메시지가 보이도록 설정했습니다.
아이디와 이메일 중복확인 API를 연결했습니다.
Input 컴포넌트의 border 색이 에러가 있는경우 빨간색으로 나타나도록 수정했습니다.
중복확인 버튼이 프로필 수정에서도 사용되기때문에 공통 컴포넌트로 생성했습니다.

## 📸 스크린샷


![녹화_2023_01_03_22_58_36_519](https://user-images.githubusercontent.com/79186378/210374890-927f4c63-dc74-4695-b4cb-403035be710d.gif)
