### PR TITLE
알림 페이지 컴포넌트 타입 수정

### DIFF
--- a/src/components/notice/NoticeItem.tsx
+++ b/src/components/notice/NoticeItem.tsx
@@ -2,8 +2,8 @@ import Image from 'next/image';
 import React from 'react';
 
 interface NoticeItemProps {
-  noticeList: { text: string; date: string; id: number }[];
-  handler: (e: number) => void;
+  noticeList: { text: string; date: string; id: string }[];
+  handler: (e: string) => void;
 }
 
 export default function NoticeItem({ noticeList, handler }: NoticeItemProps) {


### PR DESCRIPTION
## 🧑‍💻 PR 내용

알림 페이지에서 사용되는 NoticeItem 컴포넌트에서 전달받는 props의 타입을 수정했습니다.

## 📸 스크린샷

![image](https://user-images.githubusercontent.com/79186378/210476149-08c00c0b-6c27-4b00-9476-b7339898b6a8.png)

