### PR TITLE
axios, authApi 400 status 에러 핸들링

### DIFF
--- a/src/apis/_axios/instance.ts
+++ b/src/apis/_axios/instance.ts
@@ -47,7 +47,23 @@ instance.interceptors.response.use(
     const { response: res, config: reqData } = error || {};
     const { status } = res || {};
     const isUnAuthError = status === 401;
+    const isNotFoundError = status === 404;
+    const isDuplicateError = status === 409;
     const isExpiredToken = status === 444;
+
+    if (isNotFoundError) {
+      return Promise.reject(error);
+    }
+
+    if (isDuplicateError) {
+      return Promise.reject(error);
+    }
+
+    if (isUnAuthError) {
+      deleteToken();
+      window.location.href = '/auth/login';
+      return Promise.reject(error);
+    }
 
     if (isExpiredToken) {
       const token = await refreshToken();
@@ -57,12 +73,6 @@ instance.interceptors.response.use(
         reqData.headers.Authorization = `Bearer ${token?.access}`;
         return instance(reqData);
       }
-    }
-
-    if (isUnAuthError) {
-      deleteToken();
-      window.location.href = '/auth/login';
-      return Promise.reject(error);
     }
   },
 );

--- a/src/apis/auth/authApi.ts
+++ b/src/apis/auth/authApi.ts
@@ -37,22 +37,34 @@ export class AuthApi {
     return data;
   }
 
-  async postFindId(body: AuthDTOType): Promise<AuthDTOType> {
-    const { data } = await this.axios({
-      method: 'POST',
-      url: `/members/id`,
-      data: body,
-    });
-    return data;
+  async postFindId(body: AuthDTOType) {
+    try {
+      const { data } = await this.axios({
+        method: 'POST',
+        url: `/members/id`,
+        data: body,
+      });
+      return data;
+    } catch (error: any) {
+      if (error) {
+        return error.response.data;
+      }
+    }
   }
 
-  async postNewPassword(body: AuthDTOType): Promise<AuthDTOType> {
-    const { data } = await this.axios({
-      method: 'POST',
-      url: `/members/new-password`,
-      data: body,
-    });
-    return data;
+  async postNewPassword(body: AuthDTOType) {
+    try {
+      const { data } = await this.axios({
+        method: 'POST',
+        url: `/members/new-password`,
+        data: body,
+      });
+      return data;
+    } catch (error: any) {
+      if (error) {
+        return error.response.data;
+      }
+    }
   }
 
   async patchLogout(): Promise<AuthDTOType> {

--- a/src/pages/auth/id.tsx
+++ b/src/pages/auth/id.tsx
@@ -7,19 +7,30 @@ import { useRouter } from 'next/router';
 import React, { useState } from 'react';
 import Modal from '@components/common/Modal';
 import ErrorMessage from '@components/common/ErrorMessage';
+import authApi from '@apis/auth/authApi';
+interface FindIdForm {
+  name: string;
+  email: string;
+}
 
 function Id() {
   const {
     register,
     handleSubmit,
     formState: { errors },
-    watch,
-  } = useForm();
+  } = useForm<FindIdForm>();
   const [isModal, setIsModal] = useState(false);
-  const onSubmit = () => {
-    console.log(watch('name'), watch('email'));
-    setIsModal(true);
+
+  const onSubmit = async ({ name, email }: FindIdForm) => {
+    if (name && email) {
+      const data = await authApi.postFindId({
+        name,
+        email,
+      });
+      console.log(data);
+    }
   };
+
   const router = useRouter();
   const handleLeftButton = () => {
     router.push('/auth/login');

--- a/src/pages/auth/password.tsx
+++ b/src/pages/auth/password.tsx
@@ -7,19 +7,28 @@ import { useRouter } from 'next/router';
 import React, { useState } from 'react';
 import Modal from '@components/common/Modal';
 import ErrorMessage from '@components/common/ErrorMessage';
+import authApi from '@apis/auth/authApi';
+
+interface NewPasswordForm {
+  email: string;
+}
 
 function Password() {
   const {
     register,
     handleSubmit,
     formState: { errors },
-    watch,
-  } = useForm();
+  } = useForm<NewPasswordForm>();
   const [isModal, setIsModal] = useState(false);
-  const onSubmit = () => {
-    console.log(watch('email'));
-    setIsModal(true);
+  const onSubmit = async ({ email }: NewPasswordForm) => {
+    if (email) {
+      const data = await authApi.postNewPassword({
+        email,
+      });
+      console.log(data);
+    }
   };
+
   const router = useRouter();
   const handleLeftButton = () => {
     router.push('/auth/login');


### PR DESCRIPTION
## 🧑‍💻 PR 내용
_axios instance에서 상태코드를 확인하고 error Promise 객체를 반환합니다. 
authApi class 에서 try, catch로 error.response.data 객체를 반환하여 error객체를 전달받아 사용합니다. 

## 📸 스크린샷
<img width="363" alt="image" src="https://user-images.githubusercontent.com/92621861/210707405-01e4642a-e295-48eb-835c-d5c5d6ad49de.png">

<img width="262" alt="image" src="https://user-images.githubusercontent.com/92621861/210707343-92fb6c3a-1d89-43c1-a83c-0f9fb52e5e92.png">