### PR TITLE
작가 회원가입 구현 & slice수정

### DIFF
--- a/src/apis/auth/authApi.ts
+++ b/src/apis/auth/authApi.ts
@@ -19,6 +19,24 @@ export class AuthApi {
     return data;
   }
 
+  async postArtistAuth(body: AuthDTOType) {
+    try {
+      const { data } = await this.axios({
+        method: 'POST',
+        url: `/members/id`,
+        data: body,
+        headers: {
+          'Content-Type': 'multipart/form-data',
+        },
+      });
+      return data;
+    } catch (error: any) {
+      if (error) {
+        return error.response.data;
+      }
+    }
+  }
+
   async postLogin(body: AuthDTOType): Promise<AuthDTOType> {
     const { data } = await this.axios({
       method: 'POST',

--- a/src/components/common/Checkbox.tsx
+++ b/src/components/common/Checkbox.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Image from 'next/image';
-import { useRef, useState } from 'react';
+import { useRef } from 'react';
 import check from '@public/svg/icons/icon_checked.svg';
 import uncheck from '@public/svg/icons/icon_unchecked.svg';
 import checkRadio from '@public/svg/icons/icon_radio_checked.svg';
@@ -31,7 +31,6 @@ export default function CheckBox({
   handler,
   ...rest
 }: CheckBoxProps) {
-  const [isCheck, setIsCheck] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
   return kind === 'checkbox' ? (
     <Label className="cursor-pointer">

--- a/src/features/user/userSlice.ts
+++ b/src/features/user/userSlice.ts
@@ -7,15 +7,18 @@ type userInfo = {
   nickname: string;
   telephone: string;
 };
-interface userState extends userInfo {
-  tastes: string[]; //user
+type artistInfo = {
   education: string; //artist
   history: string;
   description: string;
   instagram: string;
   behance: string;
+};
+
+interface userState extends userInfo, artistInfo {
   isApprovePromotion: boolean;
   isArtist: boolean;
+  tastes: string[]; //user
 }
 
 const initialState: userState = {
@@ -53,7 +56,7 @@ const userSlice = createSlice({
       ...state,
       tastes: action.payload,
     }),
-    setArtistInfo: (state: userState, action: PayloadAction<userState>) => ({
+    setArtistInfo: (state: userState, action: PayloadAction<artistInfo>) => ({
       ...state,
       education: action.payload.education,
       history: action.payload.history,
@@ -82,4 +85,5 @@ export const {
   setArtistInfo,
   setIsArtist,
 } = userSlice.actions;
+
 export default userSlice.reducer;


### PR DESCRIPTION
## 🧑‍💻 PR 내용

작가 회원가입 구현에 필요한 틀을 잡아놓았습니다.
authApi.ts 파일에 postArtistAuth 메소드를 추가했습니다.
백 쪽에서 request 헤더 부분 수정과 정확한 에러 메시지를 명시하면 수정하도록 하겠습니다.
rtk slice에서 리듀서 함수 사용시 인자로 전달해야할 값을 명확하게 하기위해 타입을 나눴습니다.

## 📸 스크린샷

ex)
![image](https://user-images.githubusercontent.com/79186378/210739432-592ad3f2-e198-43d1-9943-cb5b9a123c40.png)
![image](https://user-images.githubusercontent.com/79186378/210739479-6988f967-443a-4ce3-94f8-d6bce8d33852.png)

리듀서 함수 setArtistInfo의 action타입이 userState여서 인자로 작가 정보 뿐만아니라, userState의 모든 필드 값을 전송하게끔 에러가 발생해서

![image](https://user-images.githubusercontent.com/79186378/210740124-5fda663b-11a4-40aa-901c-c1f59cfe0d2c.png)

위와 같이 타입을 수정하여 리듀서 함수 사용에 문제 없게 타입을 분리했습니다.