### PR TITLE
회원탈퇴 구현

### DIFF
--- a/src/apis/_axios/instance.ts
+++ b/src/apis/_axios/instance.ts
@@ -5,6 +5,7 @@ const instance = axios.create({
   baseURL: process.env.NEXT_PUBLIC_API_BASE_URL,
   headers: {
     'Content-Type': 'application/json',
+    Authorization: getToken().access,
   },
 });
 

--- a/src/apis/auth/authApi.ts
+++ b/src/apis/auth/authApi.ts
@@ -102,6 +102,23 @@ export class AuthApi {
     return data;
   }
 
+  async deleteUser(token) {
+    try {
+      const res = await this.axios({
+        method: 'DELETE',
+        url: `/members`,
+        headers: {
+          Authorization: token,
+        },
+      });
+      return res;
+    } catch (error: any) {
+      if (error) {
+        return error.response;
+      }
+    }
+  }
+
   async getCheckEmail(email): Promise<DoubleCheckDTOType> {
     try {
       const { data } = await this.axios.get(
@@ -130,8 +147,8 @@ export class AuthApi {
         `/members/check-nickname?nickname=${nickname}`,
       );
       return data;
-    } catch (err) {
-      return err.response;
+    } catch (error: any) {
+      return error.response;
     }
   }
 }

--- a/src/apis/auth/authApi.ts
+++ b/src/apis/auth/authApi.ts
@@ -102,14 +102,11 @@ export class AuthApi {
     return data;
   }
 
-  async deleteUser(token) {
+  async deleteUser() {
     try {
       const res = await this.axios({
         method: 'DELETE',
         url: `/members`,
-        headers: {
-          Authorization: token,
-        },
       });
       return res;
     } catch (error: any) {

--- a/src/pages/profile/index.tsx
+++ b/src/pages/profile/index.tsx
@@ -15,7 +15,7 @@ import Image from 'next/image';
 import { useAppSelector } from '@features/hooks';
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
-import { getToken } from '@utils/localStorage/token';
+import { isUser } from '@utils/isUser';
 
 interface defaultProps {
   [key: string]: any;
@@ -118,12 +118,7 @@ export default function Profile() {
   const { keywords, nickname } = useAppSelector((state) => state.user);
 
   useEffect(() => {
-    const token = getToken();
-    const role = token.role;
-    if (role) {
-      setRole(role);
-      // 작품목록 불러오기 API
-    }
+    console.log(isUser);
   }, [artList]);
 
   return (
@@ -158,7 +153,7 @@ export default function Profile() {
             />
           </div>
         </WelcomeBox>
-        {role === 'ROLE_ARTIST' && (
+        {isUser && (
           <div
             onClick={handleAddProfile}
             className="flex justify-between border-[1px] rounded border-[#F5535D] p-4 cursor-pointer mt-4"
@@ -183,7 +178,7 @@ export default function Profile() {
           ></Activity>
         ))}
       </section>
-      {role === 'ROLE_ARTIST' && (
+      {!isUser && (
         <section>
           <div className="my-4 flex justify-between border-t-[12px] border-[#F8F8FA] pt-4">
             <span className="text-14 text-[#191919] font-bold">작품 목록</span>

--- a/src/pages/profile/security/index.tsx
+++ b/src/pages/profile/security/index.tsx
@@ -24,8 +24,8 @@ export default function Security() {
     setIsModal(false);
   };
   const handleAcceptWithdrawal = async () => {
-    const { access } = getToken();
-    const res = await authApi.deleteUser(access);
+    const res = await authApi.deleteUser();
+    console.log(res);
     if (res?.status === 200) {
       deleteToken();
       router.push('/auth/login');

--- a/src/pages/profile/security/index.tsx
+++ b/src/pages/profile/security/index.tsx
@@ -4,6 +4,8 @@ import { useState } from 'react';
 import { useRouter } from 'next/router';
 import Image from 'next/image';
 import Modal from '@components/common/Modal';
+import authApi from '@apis/auth/authApi';
+import { getToken, deleteToken } from '@utils/localStorage/token';
 
 export default function Security() {
   const [isModal, setIsModal] = useState(false);
@@ -21,8 +23,13 @@ export default function Security() {
   const handleCloseModal = () => {
     setIsModal(false);
   };
-  const handleAcceptWithdrawal = () => {
-    console.log('회원 탈퇴 진행');
+  const handleAcceptWithdrawal = async () => {
+    const { access } = getToken();
+    const res = await authApi.deleteUser(access);
+    if (res?.status === 200) {
+      deleteToken();
+      router.push('/auth/login');
+    }
   };
 
   return (


### PR DESCRIPTION
## 🧑‍💻 PR 내용

회원탈퇴 API 연결하여 로컬스토리지 토큰 삭제하고 로그인페이지로 이동하도록 구현했습니다.
기존 프로필 페이지에서 유저, 작가 확인하는 부분 유틸함수 이용하여 수정했습니다.
authApi 파일에 deleteUser 추가했습니다.

## 📸 스크린샷


