### PR TITLE
토큰 리프래시, 키값 변경 

### DIFF
--- a/src/apis/_axios/instance.ts
+++ b/src/apis/_axios/instance.ts
@@ -69,9 +69,10 @@ instance.interceptors.response.use(
     if (isExpiredToken) {
       const token = await refreshToken();
       token['role'] = getToken().role;
-      if (token?.access) {
+      token['refreshToken'] = getToken().refreshToken;
+      if (token?.accessToken) {
         setToken(token);
-        setAuthorHeader(token.access);
+        setAuthorHeader(token.accessToken);
         // 이전 요청 재시도
         reqData.headers.Authorization = token?.access;
         return instance(reqData);

--- a/src/apis/_axios/instance.ts
+++ b/src/apis/_axios/instance.ts
@@ -13,7 +13,7 @@ const unsetAuthorHeader = () => {
 };
 
 const refreshToken = async () => {
-  const refresh = getToken().refresh;
+  const refresh = getToken().refreshToken;
   // refresh token api 호출
   const token = await instance
     .post('/members/token', {
@@ -26,11 +26,11 @@ const refreshToken = async () => {
 instance.interceptors.request.use(
   (config) => {
     const token = getToken();
-    const isAccess = !!token && !!token.access;
+    const isAccess = !!token && !!token.accessToken;
     if (isAccess) {
       config.headers = {
         'Content-Type': 'application/json',
-        Authorization: token.access,
+        Authorization: token.accessToken,
       };
     }
     return config;

--- a/src/apis/auth/authApi.ts
+++ b/src/apis/auth/authApi.ts
@@ -1,8 +1,6 @@
 import instance from '@apis/_axios/instance';
 import { AxiosInstance } from 'axios';
-
 import { AuthDTOType, DoubleCheckDTOType } from './authApi.type';
-import { getToken } from '@utils/localStorage/token';
 
 export class AuthApi {
   axios: AxiosInstance = instance;

--- a/src/apis/auth/authApi.ts
+++ b/src/apis/auth/authApi.ts
@@ -14,7 +14,7 @@ export class AuthApi {
     await this.axios.post('/members/join', body);
   }
 
-  async getUserProfile() {
+  async getUserProfile(): Promise<AuthDTOType> {
     return await this.axios(`/members/me`);
   }
 

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -19,7 +19,7 @@ export default function App({ Component, pageProps }: AppProps) {
   useEffect(() => {
     if (router.pathname.includes('auth')) return;
     const token = getToken();
-    if (!token.access) router.replace('/auth/login');
+    if (!token.accessToken) router.replace('/auth/login');
   }, [router]);
 
   return (

--- a/src/pages/auth/kakao/callback.tsx
+++ b/src/pages/auth/kakao/callback.tsx
@@ -15,8 +15,8 @@ export default function KakaoCallback() {
       .get(`/oauth2/kakao?code=${code}`)
       .then((res) => {
         const token: Token = {
-          access: res.data.accessToken,
-          refresh: res.data.refreshToken,
+          accessToken: res.data.accessToken,
+          refreshToken: res.data.refreshToken,
           role: 'ROLE_USER',
         };
         if (token) setToken(token);

--- a/src/pages/auth/login.tsx
+++ b/src/pages/auth/login.tsx
@@ -42,8 +42,8 @@ function Login() {
     });
     if (res.status === 200) {
       const token: Token = {
-        access: res.data.accessToken,
-        refresh: res.data.refreshToken,
+        accessToken: res.data.accessToken,
+        refreshToken: res.data.refreshToken,
         role: res.data.roles,
       };
       if (token) setToken(token);

--- a/src/pages/auth/naver/callback.tsx
+++ b/src/pages/auth/naver/callback.tsx
@@ -16,8 +16,8 @@ export default function NaverCallback() {
       .get(`/oauth2/naver?code=${code}&state=${state}`)
       .then((res) => {
         const token: Token = {
-          access: res.data.accessToken,
-          refresh: res.data.refreshToken,
+          accessToken: res.data.accessToken,
+          refreshToken: res.data.refreshToken,
           role: 'ROLE_USER',
         };
         if (token) setToken(token);

--- a/src/pages/profile/edit.tsx
+++ b/src/pages/profile/edit.tsx
@@ -5,7 +5,7 @@ import Navigate from '@components/common/Navigate';
 import DoubleCheckButton from '@components/common/DoubleCheckButton';
 import authApi from '@apis/auth/authApi';
 import React, { useState, useEffect } from 'react';
-import { useAppDispatch, useAppSelector } from '@features/hooks';
+import { useAppSelector } from '@features/hooks';
 import { useForm } from 'react-hook-form';
 import Image from 'next/image';
 import { useRouter } from 'next/router';
@@ -111,7 +111,6 @@ export default function Edit() {
     // 프로필 수정 API전송 (PATCH)
   };
 
-  const dispatch = useAppDispatch();
   const { education, history, description, instagram, behance } =
     useAppSelector((state) => state.user);
 

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -1,19 +1,19 @@
 export interface Member extends User, Artist {
-  keywords: string[];
+  keywords?: string[];
 }
 
 export interface User {
   userId: string;
   password: string;
-  email: string;
-  nickname: string;
-  telephone: string;
+  email?: string;
+  nickname?: string;
+  telephone?: string;
 }
 
 export interface Artist {
-  education: string;
-  history: string;
-  description: string;
-  instagram: string;
-  behance: string;
+  education?: string;
+  history?: string;
+  description?: string;
+  instagram?: string;
+  behance?: string;
 }

--- a/src/utils/localStorage/token/index.ts
+++ b/src/utils/localStorage/token/index.ts
@@ -8,15 +8,15 @@ import {
 const TOKEN_KEY = CONFIG.AUTH_TOKEN_KEY || '@token';
 
 export type Token = {
-  access: string | null;
-  refresh: string | null;
+  accessToken: string | null;
+  refreshToken: string | null;
   role: string | null;
 };
 
 export const getToken = () => {
   const token = getLocalStorage<Token>(TOKEN_KEY, {
-    access: null,
-    refresh: null,
+    accessToken: null,
+    refreshToken: null,
     role: null,
   });
   return token;


### PR DESCRIPTION
## 🧑‍💻 PR 내용
프론트에서 저장되는 토큰의 key 값들이 서버와 달라서 refresh요청이 잘 이루어지지 않았었고 이러한 부분이 없게 하기위해서 토큰의 key 값을 서버에서 주는 값과 동일하게 하였습니다. 
authApi에서 return Promise type을 명시해주었습니다. 
## 📸 스크린샷
accees -> accessToken
refresh -> refreshToken
<img width="182" alt="image" src="https://user-images.githubusercontent.com/92621861/211857261-09fda519-22dd-41af-a3e4-7a6ba47ff1a8.png">

