### PR TITLE
feat : 아이디 저장 기능 추가

### DIFF
--- a/src/utils/localStorage/token/index.ts
+++ b/src/utils/localStorage/token/index.ts
@@ -11,7 +11,7 @@ export type Token = {
   accessToken: string | null;
   refreshToken: string | null;
   role: string | null;
-};
+}; 
 
 export const getToken = () => {
   const token = getLocalStorage<Token>(TOKEN_KEY, {


### PR DESCRIPTION
## 🧑‍💻 PR 내용

1. term1,term2 -> 변수만 봐서 어떤 것을 의미하는지 알 수 없어서 autoLogin, idSave로 변경하였습니다.
2. localStorage에 아이디저장 버튼을 전에 on으로했다면 idSave = 'true', off면 idSave='false' 로 저장됩니다.
3. 자동 로그인은, 시작 화면을 auth/login이 아니라 /home으로 하고, access token이 유효하다면 그대로, 그렇지 않다면 login으로 돌려보내는 식으로 하면 될 것 같습니다.

## 📸 스크린샷

![녹화_2023_01_16_10_24_23_216](https://user-images.githubusercontent.com/62178788/212579746-bc122d26-220a-439e-9e67-7c68111c720c.gif)

