### PR TITLE
전시회 페이지 그림확대시 배경 크기 수정 & swiper navigation 버튼 구현

### DIFF
--- a/src/components/exhibition/Modal.tsx
+++ b/src/components/exhibition/Modal.tsx
@@ -24,7 +24,7 @@ absolute w-[327px] h-[280px] m-auto rounded-[8px] backdrop-blur-[25.5px] p-5 tra
 ) =>
   p.$open
     ? 'bg-gradient-to-r from-[#FFFFFF]/[.16] to-[#FFFFFF]/[.46] translate-y-[-250px]'
-    : 'bg-gradient-to-b from-[#FFFFFF]/[.16] to-[#FFFFFF]/[.46] translate-y-[120px] opacity-60'}
+    : 'bg-gradient-to-b from-[#FFFFFF]/[.16] to-[#FFFFFF]/[.46] translate-y-[120px] text-[#191919]/40'}
 `;
 const ModalHeader = tw.div<DefaultProps>`
 text-[#424242] text-20 flex justify-between font-bold`;

--- a/src/pages/exhibition/index.tsx
+++ b/src/pages/exhibition/index.tsx
@@ -2,7 +2,7 @@ import 'swiper/css';
 import tw from 'tailwind-styled-components';
 import Modal from '@components/exhibition/Modal';
 import Navigate from '@components/common/Navigate';
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import Image from 'next/image';
 import React from 'react';
 import { Navigation } from 'swiper';
@@ -41,25 +41,19 @@ const ExhibitionLayout = tw.div<DefaultProps>`
 font-Pretendard w-full px-6 pt-[45px] border h-[812px] relative overflow-y-hidden overflow-x-hidden
 `;
 
-const NextSlide = ({ children }) => {
-  const swiper = useSwiper();
-  return <button onClick={() => swiper.slideNext()}>{children}</button>;
-};
-
-const PrevSlide = ({ children }) => {
-  const swiper = useSwiper();
-  return <button onClick={() => swiper.slidePrev()}>{children}</button>;
-};
+const SwiperButtonDiv = tw.div<DefaultProps>`
+bg-[rgba(153,153,153,0.24)] rounded-[10px] w-8 h-8 flex justify-center cursor-pointer
+`;
 
 export default function Exhibition() {
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const [modal, setModal] = useState<boolean>(true);
   const [isExpansion, setExpansion] = useState<boolean>(false);
+
+  const swiperRef = useRef<any>(null);
+
   const router = useRouter();
 
-  const onCloseModal = () => {
-    setIsOpen(false);
-  };
   const handleLeftButton = () => {
     // 작품 더보기 페이지로 이동
     router.push('/');
@@ -68,6 +62,10 @@ export default function Exhibition() {
   const handleRightButton = () => {
     // 해당 작품 작가 프로필로 이동
     router.push('/');
+  };
+
+  const onCloseModal = () => {
+    setIsOpen(false);
   };
 
   const handleSwipeArrow = () => {
@@ -92,66 +90,83 @@ export default function Exhibition() {
 
   return (
     <ExhibitionLayout>
-      <Image
-        alt="exhibition_bg"
-        src="/svg/icons/bg_exhibition.jpg"
-        quality={100}
-        fill
-        sizes="100vh"
-        style={{
-          objectFit: 'cover',
-        }}
-      />
       {isExpansion ? (
-        <Image
-          alt="canvas"
-          src="/svg/icons/bg_canvas.svg"
-          quality={100}
-          width={400}
-          height={0}
-          sizes="100vh"
-          style={{
-            objectFit: 'contain',
-          }}
-          className="scale-[1.8] top-[240px] right-[-3px] absolute"
-        />
+        <>
+          <Image
+            alt="exhibition_bg"
+            src="/svg/icons/bg_exhibition.jpg"
+            quality={100}
+            width={400}
+            height={0}
+            sizes="100vh"
+            style={{
+              objectFit: 'contain',
+            }}
+            className="scale-[1.8] top-[240px] right-[-3px] absolute"
+          />
+          <Image
+            alt="canvas"
+            src="/svg/icons/bg_canvas.svg"
+            quality={100}
+            width={400}
+            height={0}
+            sizes="100vh"
+            style={{
+              objectFit: 'contain',
+            }}
+            className="scale-[1.8] top-[240px] right-[-3px] absolute"
+          />
+        </>
       ) : (
-        <Image
-          alt="canvas"
-          src="/svg/icons/bg_canvas.svg"
-          quality={100}
-          fill
-          sizes="100vh"
-          style={{
-            objectFit: 'cover',
-          }}
-        />
+        <>
+          <Image
+            alt="exhibition_bg"
+            src="/svg/icons/bg_exhibition.jpg"
+            quality={100}
+            fill
+            sizes="100vh"
+            style={{
+              objectFit: 'cover',
+            }}
+          />
+          <Image
+            alt="canvas"
+            src="/svg/icons/bg_canvas.svg"
+            quality={100}
+            fill
+            sizes="100vh"
+            style={{
+              objectFit: 'cover',
+            }}
+          />
+        </>
       )}
       <Navigate message="전시회" isRightButton={false} />
-      <Swiper
-        className="h-full"
-        modules={[Navigation]}
-        navigation
-        spaceBetween={50}
-      >
-        <div className="flex justify-between absolute w-[351px] top-[300px] ml-[-15px] z-50">
-          <PrevSlide>
-            <Image
-              src="/svg/icons/icon_back_white.svg"
-              alt="back"
-              width={10}
-              height={10}
-            />
-          </PrevSlide>
-          <NextSlide>
-            <Image
-              src="/svg/icons/icon_arrow_white.svg"
-              alt="back"
-              width={10}
-              height={10}
-            />
-          </NextSlide>
-        </div>
+      <Swiper className="h-full" ref={swiperRef} spaceBetween={50}>
+        {!isExpansion && !isOpen && (
+          <div className="flex justify-between w-[99%] absolute top-[180px] z-50">
+            <SwiperButtonDiv
+              onClick={() => swiperRef.current.swiper.slidePrev()}
+            >
+              <Image
+                src="/svg/icons/icon_back_white.svg"
+                alt="back"
+                width={10}
+                height={0}
+              />
+            </SwiperButtonDiv>
+            <SwiperButtonDiv
+              onClick={() => swiperRef.current.swiper.slideNext()}
+            >
+              <Image
+                src="/svg/icons/icon_arrow_white.svg"
+                alt="back"
+                width={10}
+                height={0}
+              />
+            </SwiperButtonDiv>
+          </div>
+        )}
         {DUMP_ART_LISTS.map((art, idx) => (
           <SwiperSlide key={idx}>
             {isExpansion ? (


### PR DESCRIPTION
## 🧑‍💻 PR 내용

전시회 페이지에서 그림 확대시에 뒷 배경 그림자도 그림 확대 비율에 맞게 확대되도록 수정했습니다.
swiper의 navigation 버튼을 커스텀하여  요청 디자인에 맞게 구현했습니다.
modal이 close 상태일 때의 디자인을 수정했습니다.

## 📸 스크린샷


![녹화_2023_01_19_14_06_07_786](https://user-images.githubusercontent.com/79186378/213360615-34a4c5f7-a4ea-4f6a-adf0-510754253113.gif)
