### PR TITLE
auth 타입 에러 수정 및 리팩토링

### DIFF
--- a/src/apis/auth/authApi.ts
+++ b/src/apis/auth/authApi.ts
@@ -9,7 +9,7 @@ export class AuthApi {
     if (axios) this.axios = axios;
   }
 
-  async postLogin(body: { userId: string; password: string }) {
+  async postLogin(body: { userId: string | null; password: string }) {
     try {
       return await axios.post(
         `${process.env.NEXT_PUBLIC_API_BASE_URL}/members/login`,
@@ -27,19 +27,30 @@ export class AuthApi {
     return data;
   }
 
-  async postFindId(body: string) {
+  async postFindId(email: string) {
     try {
-      const res = await this.axios({
-        method: 'POST',
-        url: `/members/id`,
-        data: body,
+      return await this.axios.post(`/members/id`, {
+        email,
       });
-      return res;
     } catch (error: any) {
       if (error) {
-        return error.response;
+        return error;
       }
     }
+  }
+
+  async postNewPassword(email: string) {
+    try {
+      return await this.axios.post(`/members/new-password`, {
+        email,
+      });
+    } catch (error: any) {
+      return error;
+    }
+  }
+
+  async postLogout() {
+    await this.axios.post('/members/logout');
   }
 
   async postPassword(password: string) {
@@ -52,10 +63,6 @@ export class AuthApi {
         return error;
       }
     }
-  }
-
-  async postLogout() {
-    await this.axios.post('/members/logout');
   }
 
   async patchUserInfo(formData: any) {

--- a/src/components/common/Modal.tsx
+++ b/src/components/common/Modal.tsx
@@ -17,10 +17,10 @@ interface DefaultProps {
 const ModalTag = tw.div<DefaultProps>``;
 
 const ModalBackground = tw.div`
-  absolute inset-0 bg-[#767676] opacity-80 backdrop-blur-3xl
+  absolute inset-0 bg-[#767676] opacity-80 backdrop-blur-3xl z-10
 `;
 const ModalInner = tw.div<DefaultProps>`
-  z-10 w-[327px] h-[156px] absolute inset-0 m-auto
+  z-20 w-[327px] h-[156px] absolute inset-0 m-auto
 `;
 const ModalMessage = tw.div`
 h-[104px] bg-white text-[#191919] text-14 rounded-t-[4px] flex items-center justify-center font-bold 

--- a/src/pages/auth/join02.tsx
+++ b/src/pages/auth/join02.tsx
@@ -98,7 +98,8 @@ export default function Join02() {
     router.push('/auth/join03');
   };
 
-  const handleValidateCheck = async (e: { target: { id: any } }) => {
+  const handleValidateCheck = async (e: { target: { id: string } }) => {
+    console.log(e.target.id);
     let data: { status: number };
     switch (e.target.id) {
       case 'id':
@@ -221,7 +222,7 @@ export default function Join02() {
             $valid={!isValidate.nickname}
             onClick={handleValidateCheck}
             id="nickname"
-            text={isValidate.nicknaame ? '사용가능' : '중복확인'}
+            text={isValidate.nickname ? '사용가능' : '중복확인'}
           />
           {errors.nickname && (
             <ErrorMessage message={errors.nickname.message} />

--- a/src/pages/auth/join03.tsx
+++ b/src/pages/auth/join03.tsx
@@ -3,7 +3,6 @@ import ErrorMessage from '@components/common/ErrorMessage';
 import Layout from '@components/common/Layout';
 import { useAppSelector } from '@features/hooks';
 import { useRouter } from 'next/router';
-import { User } from 'types/user';
 
 import Button from '../../components/common/Button';
 import useUserJoin from '../../hooks/queries/useUserJoin';

--- a/src/pages/auth/join04.tsx
+++ b/src/pages/auth/join04.tsx
@@ -2,7 +2,6 @@ import ErrorMessage from '@components/common/ErrorMessage';
 import Layout from '@components/common/Layout';
 import { useAppSelector } from '@features/hooks';
 import { useState } from 'react';
-import { Member } from 'types/user';
 import useUserJoin from '../../hooks/queries/useUserJoin';
 import SelectKeyword from '@components/common/Selectkeyword';
 

--- a/src/pages/auth/login.tsx
+++ b/src/pages/auth/login.tsx
@@ -6,7 +6,11 @@ import Input from '@components/common/Input';
 import Layout from '@components/common/Layout';
 import SocialLoginButton from '@components/login/SocialLoginButton';
 import { setToken, Token } from '@utils/localStorage/token';
-import { setLocalStorage, getLocalStorage } from '@utils/localStorage/helper';
+import {
+  setLocalStorage,
+  getLocalStorage,
+  removeLocalStorage,
+} from '@utils/localStorage/helper';
 import Image from 'next/image';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
@@ -14,7 +18,7 @@ import React, { useState, useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 
 interface LoginForm {
-  userId: string;
+  userId: string | null;
   password: string;
 }
 
@@ -30,6 +34,7 @@ function Login() {
     },
   });
   const [checkedTerm, setCheckedTerm] = useState<string[]>([]);
+  console.log(checkedTerm);
   useEffect(() => {
     if (getLocalStorage('idSave') === 'true') {
       setCheckedTerm(['idSave']);
@@ -40,6 +45,7 @@ function Login() {
       setLocalStorage('idSave', 'true');
     } else {
       setLocalStorage('idSave', 'false');
+      removeLocalStorage('savedId');
     }
   }, [checkedTerm]);
 
@@ -64,7 +70,7 @@ function Login() {
       const token: Token = {
         accessToken: res.data.accessToken,
         refreshToken: res.data.refreshToken,
-        role: res.data.roles,
+        roles: res.data.roles,
       };
       if (token) setToken(token);
       router.push('/home');

--- a/src/pages/auth/password.tsx
+++ b/src/pages/auth/password.tsx
@@ -21,11 +21,10 @@ function Password() {
     formState: { errors },
   } = useForm<NewPasswordForm>();
   const [isModal, setIsModal] = useState(false);
+
   const onSubmit = async ({ email }: NewPasswordForm) => {
     if (email) {
-      const res = await authApi.postNewPassword({
-        email,
-      });
+      const res = await authApi.postNewPassword(email);
       if (res.status === 200) {
         setIsModal(true);
       } else if (res.status === 404 && res.data.code === 'NOT_FOUND_EMAIL') {


### PR DESCRIPTION
## 🧑‍💻 PR 내용

전체적인 auth 관련 페이지들 타입 수정했습니다.
authApi 파일에 비밀번호 찾기 API 누락된것 추가해서 연결했습니다.
아이디, 비밀번호 찾기 후 모달창 z-index 수정했습니다.
아이디 저장 해제하면 저장되어있던 아이디 로컬스토리지에서 삭제되도록 반영했습니다.

## 📸 스크린샷

