### PR TITLE
instace 수정 & API 구현(판매 페이지 API, 작가 정보 수정 API, 취향 변경 API)

### DIFF
--- a/src/apis/_axios/instance.ts
+++ b/src/apis/_axios/instance.ts
@@ -1,16 +1,9 @@
-import axios from 'axios'
-import { deleteToken, getToken, setToken } from '@utils/localStorage/token'
+import axios from 'axios';
+import { deleteToken, getToken, setToken } from '@utils/localStorage/token';
 
 const instance = axios.create({
   baseURL: process.env.NEXT_PUBLIC_API_BASE_URL,
 });
-
-const setAuthorHeader = (token: string) => {
-  if (token) instance.defaults.headers.common['Authorization'] = token;
-};
-const unsetAuthorHeader = () => {
-  delete instance.defaults.headers.common['Authorization'];
-};
 
 const refreshToken = async () => {
   const refresh = getToken().refreshToken;
@@ -28,13 +21,10 @@ const refreshToken = async () => {
 instance.interceptors.request.use(
   (config) => {
     const token = getToken();
-    const isAccess = !!token && !!token.accessToken;
-    if (isAccess) {
-      config.headers = {
-        'Content-Type': 'application/json',
-        Authorization: token.accessToken,
-      };
-    }
+    config.headers = {
+      ...config.headers,
+      Authorization: token.accessToken,
+    };
     return config;
   },
   (error) => {
@@ -69,7 +59,6 @@ instance.interceptors.response.use(
         token['refreshToken'] = getToken().refreshToken;
         if (token?.accessToken) {
           setToken(token);
-          setAuthorHeader(token.accessToken);
           reqData.headers.Authorization = token?.access;
           return instance(reqData);
         }
@@ -81,6 +70,6 @@ instance.interceptors.response.use(
   },
 );
 
-export { setAuthorHeader, unsetAuthorHeader };
+// export { setAuthorHeader, unsetAuthorHeader };
 
 export default instance;

--- a/src/apis/artwork/artworkApi.ts
+++ b/src/apis/artwork/artworkApi.ts
@@ -1,19 +1,15 @@
-import axios from 'axios'
-
-import { getToken } from '@utils/localStorage/token/index'
-import { ArtworkDTOType } from './artworkApi.type'
+import { ArtworkDTOType } from './artworkApi.type';
+import instance from '@apis/_axios/instance';
 
 export class ArtworkApi {
   async postArtwork(body: FormData): Promise<ArtworkDTOType> {
     try {
-      const token = getToken();
-      const { data } = await axios.post(
+      const { data } = await instance.post(
         `${process.env.NEXT_PUBLIC_API_BASE_URL}/art-works`,
         body,
         {
           headers: {
             'Content-Type': 'multipart/form-data',
-            Authorization: token.accessToken,
           },
         },
       );

--- a/src/apis/auth/authApi.ts
+++ b/src/apis/auth/authApi.ts
@@ -1,9 +1,9 @@
-import instance from '@apis/_axios/instance'
-import axios from 'axios'
-import { AxiosInstance } from 'axios'
-import { getToken } from '@utils/localStorage/token'
+import instance from '@apis/_axios/instance';
+import axios from 'axios';
+import { AxiosInstance } from 'axios';
+import { getToken } from '@utils/localStorage/token';
 
-import { AuthDTOType } from './authApi.type'
+import { AuthDTOType } from './authApi.type';
 
 export class AuthApi {
   axios: AxiosInstance = instance;
@@ -69,16 +69,41 @@ export class AuthApi {
 
   async patchUserInfo(formData: any) {
     try {
-      const token = getToken();
-      const res = await axios.patch(
+      const res = await instance.patch(
         `${process.env.NEXT_PUBLIC_API_BASE_URL}/members`,
         formData,
         {
           headers: {
             'Content-Type': 'multipart/form-data',
-            Authorization: token.accessToken,
           },
         },
+      );
+      return res;
+    } catch (err: any) {
+      return err;
+    }
+  }
+  async patchArtistInfo(formData: any) {
+    try {
+      const res = await instance.patch(
+        `${process.env.NEXT_PUBLIC_API_BASE_URL}/artists`,
+        formData,
+        {
+          headers: {
+            'Content-Type': 'multipart/form-data',
+          },
+        },
+      );
+      return res;
+    } catch (err: any) {
+      return err;
+    }
+  }
+  async patchKeyword(body: string[]) {
+    try {
+      const res = await instance.patch(
+        `${process.env.NEXT_PUBLIC_API_BASE_URL}/members/keywords`,
+        body,
       );
       return res;
     } catch (err: any) {

--- a/src/hooks/queries/useGetSellingArtWork.ts
+++ b/src/hooks/queries/useGetSellingArtWork.ts
@@ -1,0 +1,27 @@
+import instance from '@apis/_axios/instance';
+import { useQuery } from 'react-query';
+import { useState } from 'react';
+
+export default function useGetSellingArtWork() {
+  const [sellingArtWork, setSellingArtWork] = useState<Member[]>();
+
+  const query = useQuery(
+    'useSellingArtWork',
+    async () => {
+      const res = await instance('/art-works/me');
+      console.log(res);
+      return res;
+    },
+    {
+      retry: 0,
+      refetchOnWindowFocus: false,
+      onSuccess: (res: any) => {
+        setSellingArtWork(res?.data);
+      },
+      onError: (error: any) => {
+        console.log(error);
+      },
+    },
+  );
+  return { ...query, sellingArtWork };
+}

--- a/src/pages/home/post.tsx
+++ b/src/pages/home/post.tsx
@@ -123,18 +123,18 @@ export default function Post() {
     } = form;
     const formData = new FormData();
     formData.append('title', title);
-    formData.append('productionYear', productionYear);
+    formData.append('productionYear', productionYear + '');
     formData.append('description', description);
     formData.append('material', material);
-    formData.append('frame', frame + '' === '있음');
-    formData.append('width', width);
-    formData.append('length', length);
-    formData.append('height', height);
+    formData.append('frame', (frame + '' === '있음') + '');
+    formData.append('width', JSON.stringify(width));
+    formData.append('length', length + '');
+    formData.append('height', height + '');
     formData.append('size', size);
-    formData.append('price', price);
+    formData.append('price', price + '');
     formData.append('status', status);
     formData.append('statusDescription', statusDescription);
-    formData.append('keywords', keywordList);
+    formData.append('keywords', keywordList + '');
 
     if (file.length == 1) {
       formData.append('image', file[0]);
@@ -414,7 +414,7 @@ export default function Post() {
           )}
         </div>
         <div className="h-[336px] relative">
-          <div className="w-[375px] h-[376px] absolute -left-6 bottom-0">
+          <div className="w-[375px] h-[376px] absolute -left-6 -bottom-10">
             <div className="mt-12 h-4 bg-[#F8F8FA]"></div>
             <div className="text-12 px-6">
               <p className="font-medium mt-8">

--- a/src/pages/home/post.tsx
+++ b/src/pages/home/post.tsx
@@ -127,7 +127,7 @@ export default function Post() {
     formData.append('description', description);
     formData.append('material', material);
     formData.append('frame', (frame + '' === '있음') + '');
-    formData.append('width', JSON.stringify(width));
+    formData.append('width', width + '');
     formData.append('length', length + '');
     formData.append('height', height + '');
     formData.append('size', size);

--- a/src/pages/home/post.tsx
+++ b/src/pages/home/post.tsx
@@ -1,20 +1,20 @@
-import artworkApi from '@apis/artwork/artworkApi'
-import ErrorMessage from '@components/common/ErrorMessage'
-import Input from '@components/common/Input'
-import Layout from '@components/common/Layout'
-import Modal from '@components/common/Modal'
-import Navigate from '@components/common/Navigate'
-import Select from '@components/common/Select'
-import GenreModal from '@components/home/post/GenreModal'
-import GuaranteeModal from '@components/home/post/GuaranteeModal'
-import KeywordModal from '@components/home/post/KeywordModal.tsx'
-import FileItem from '@components/inquiry/FileItem'
-import Image from 'next/image'
-import React, { useEffect, useState } from 'react'
-import { useForm } from 'react-hook-form'
-import { useRouter } from 'next/router'
-import { getToken } from '@utils/localStorage/token'
-import { dataURLtoFile } from '@utils/dataURLtoFile'
+import artworkApi from '@apis/artwork/artworkApi';
+import ErrorMessage from '@components/common/ErrorMessage';
+import Input from '@components/common/Input';
+import Layout from '@components/common/Layout';
+import Modal from '@components/common/Modal';
+import Navigate from '@components/common/Navigate';
+import Select from '@components/common/Select';
+import GenreModal from '@components/home/post/GenreModal';
+import GuaranteeModal from '@components/home/post/GuaranteeModal';
+import KeywordModal from '@components/home/post/KeywordModal.tsx';
+import FileItem from '@components/inquiry/FileItem';
+import Image from 'next/image';
+import React, { useEffect, useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { useRouter } from 'next/router';
+import { getToken } from '@utils/localStorage/token';
+import { dataURLtoFile } from '@utils/dataURLtoFile';
 
 const ARTWORK_STATUS = [
   { value: '매우 좋음' },
@@ -63,7 +63,7 @@ export default function Post() {
 
   const router = useRouter();
 
-  if (getToken().roles !== 'ARTIST') {
+  if (getToken().roles !== 'ROLE_ARTIST') {
     router.push('/home');
   }
 
@@ -123,22 +123,18 @@ export default function Post() {
     } = form;
     const formData = new FormData();
     formData.append('title', title);
-    formData.append('productionYear', JSON.stringify(productionYear));
+    formData.append('productionYear', productionYear);
     formData.append('description', description);
     formData.append('material', material);
-    if (frame + '' === '있음') {
-      formData.append('frame', JSON.stringify(true));
-    } else {
-      formData.append('frame', JSON.stringify(false));
-    }
-    formData.append('width', JSON.stringify(width));
-    formData.append('length', JSON.stringify(length));
-    formData.append('height', JSON.stringify(height));
+    formData.append('frame', frame + '' === '있음');
+    formData.append('width', width);
+    formData.append('length', length);
+    formData.append('height', height);
     formData.append('size', size);
-    formData.append('price', JSON.stringify(price));
+    formData.append('price', price);
     formData.append('status', status);
     formData.append('statusDescription', statusDescription);
-    formData.append('keywords', JSON.stringify(keywordList));
+    formData.append('keywords', keywordList);
 
     if (file.length == 1) {
       formData.append('image', file[0]);
@@ -214,11 +210,11 @@ export default function Post() {
                 height={17}
               />
               <div className="text-12 text-[#999999]">
-                {fileLists.length ? `${fileLists.length}/5` : '0/5'}
+                {fileLists.length > 0 ? `${fileLists.length}/5` : '0/5'}
               </div>
             </div>
           </label>
-          {fileLists.length && (
+          {fileLists.length > 0 && (
             <div className="flex flex-wrap">
               {fileLists.map((file, idx) => (
                 <FileItem

--- a/src/pages/profile/edit.tsx
+++ b/src/pages/profile/edit.tsx
@@ -1,17 +1,17 @@
-import authApi from '@apis/auth/authApi'
-import DoubleCheckButton from '@components/common/DoubleCheckButton'
-import ErrorMessage from '@components/common/ErrorMessage'
-import Input from '@components/common/Input'
-import Layout from '@components/common/Layout'
-import Loader from '@components/common/Loader'
-import Navigate from '@components/common/Navigate'
-import useGetProfile from '@hooks/queries/useGetProfile'
-import Image from 'next/image'
-import React, { useEffect, useState } from 'react'
-import { useForm } from 'react-hook-form'
-import { useRouter } from 'next/router'
-import { isUser } from '@utils/isUser'
-import { makeBlob } from '@utils/makeBlob'
+import authApi from '@apis/auth/authApi';
+import DoubleCheckButton from '@components/common/DoubleCheckButton';
+import ErrorMessage from '@components/common/ErrorMessage';
+import Input from '@components/common/Input';
+import Layout from '@components/common/Layout';
+import Loader from '@components/common/Loader';
+import Navigate from '@components/common/Navigate';
+import useGetProfile from '@hooks/queries/useGetProfile';
+import Image from 'next/image';
+import React, { useEffect, useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { useRouter } from 'next/router';
+import { isUser } from '@utils/isUser';
+import { makeBlob } from '@utils/makeBlob';
 
 export default function Edit() {
   const [isNicknameValidate, setIsNicknameValidate] = useState<boolean>(true);
@@ -44,6 +44,7 @@ export default function Edit() {
   }, [nickname]);
 
   useEffect(() => {
+    console.log(profile);
     if (!profile) return;
     setUserInfo(
       (prev) =>
@@ -124,17 +125,21 @@ export default function Edit() {
       formData.append('image', new File([''], ''));
     }
 
-    if (instagram) formData.append('instagram', instagram);
-    if (behance) formData.append('behance', behance);
-
     if (!isUser) {
       if (education) formData.append('education', education);
       if (history) formData.append('history', history);
       if (description) formData.append('description', description);
-    }
 
-    const response = await authApi.patchUserInfo(formData);
-    if (response.status === 200) {
+      if (instagram) formData.append('instagram', instagram);
+      if (behance) formData.append('behance', behance);
+    }
+    let response;
+    if (isUser) {
+      response = await authApi.patchUserInfo(formData);
+    } else {
+      response = await authApi.patchArtistInfo(formData);
+    }
+    if (response?.status === 200) {
       router.push('/home');
     }
   };

--- a/src/pages/profile/index.tsx
+++ b/src/pages/profile/index.tsx
@@ -1,15 +1,15 @@
-import DivisionBar from '@components/common/DivisionBar'
-import Layout from '@components/common/Layout'
-import Loader from '@components/common/Loader'
-import Navigate from '@components/common/Navigate'
-import Tab from '@components/common/Tab'
-import Activity from '@components/profile/Activity'
-import SettingItem from '@components/profile/SettingItem'
-import useGetProfile from '@hooks/queries/useGetProfile'
-import Image from 'next/image'
-import tw from 'tailwind-styled-components'
-import { isUser } from '@utils/isUser'
-import { useRouter } from 'next/router'
+import DivisionBar from '@components/common/DivisionBar';
+import Layout from '@components/common/Layout';
+import Loader from '@components/common/Loader';
+import Navigate from '@components/common/Navigate';
+import Tab from '@components/common/Tab';
+import Activity from '@components/profile/Activity';
+import SettingItem from '@components/profile/SettingItem';
+import useGetProfile from '@hooks/queries/useGetProfile';
+import Image from 'next/image';
+import tw from 'tailwind-styled-components';
+import { isUser } from '@utils/isUser';
+import { useRouter } from 'next/router';
 
 interface defaultProps {
   [key: string]: any;
@@ -189,23 +189,23 @@ export default function Profile() {
         <div className="my-4 relative">
           <span className="text-14 text-[#191919] font-bold">
             취향 목록
-            {userInfo && userInfo.keywords && userInfo.keywords.length ? (
+            {userInfo?.keywords?.length && (
               <Image
                 src="/svg/icons/icon_pencil_black.svg"
                 alt="edit_keywords"
                 width="18"
                 height="0"
-                className="absolute left-[4rem] top-1"
+                className="absolute left-[4rem] top-1 cursor-pointer"
+                onClick={() => {
+                  router.push('/profile/keyword');
+                }}
               />
-            ) : (
-              ''
             )}
           </span>
         </div>
-        <DivisionBar className="my-5" />
-        {userInfo && userInfo.keywords && userInfo?.keywords?.length ? (
+        {userInfo?.keywords?.length ? (
           <div className="flex flex-wrap mb-8">
-            {userInfo?.keywords?.map((keyword) => (
+            {userInfo?.keywords?.map((keyword: string) => (
               <span
                 className="border-[1px] border-[#DBDBDB] rounded-[19px] px-3 py-1 mr-2 mb-1 last:mr-0 text-14 text-[#767676] "
                 key={keyword}
@@ -233,6 +233,7 @@ export default function Profile() {
           </div>
         )}
       </section>
+      <DivisionBar className="my-5" />
       <section>
         {SettingLists.map((setting: SettingList) => (
           <SettingItem

--- a/src/pages/profile/keyword.tsx
+++ b/src/pages/profile/keyword.tsx
@@ -1,18 +1,26 @@
-import authApi from '@apis/auth/authApi'
-import Layout from '@components/common/Layout'
-import SelectKeyword from '@components/profile/Selectkeyword'
-import { useState } from 'react'
+import authApi from '@apis/auth/authApi';
+import Layout from '@components/common/Layout';
+import SelectKeyword from '@components/profile/Selectkeyword';
+import useGetProfile from '@hooks/queries/useGetProfile';
+import { useState, useEffect } from 'react';
 
 export default function Keyword() {
   const [keywordList, setKeywordList] = useState<string[]>([]);
-  const handleSubmit = async (e: { target: { id: string } }) => {
-    const formData = new FormData();
+  const { userInfo } = useGetProfile();
+
+  useEffect(() => {
+    setKeywordList(userInfo?.keywords);
+  }, [userInfo]);
+
+  console.log(userInfo);
+  const handleSubmit = async (e: any) => {
+    let response;
     if (e.target.id === 'skip') {
-      formData.append('keywords', JSON.stringify([]));
+      response = await authApi.patchKeyword(userInfo?.keywords);
     } else {
-      formData.append('keywords', JSON.stringify(keywordList));
+      response = await authApi.patchKeyword(keywordList);
     }
-    const res = await authApi.patchUserInfo(formData);
+    console.log(response);
   };
   return (
     <Layout>

--- a/src/pages/profile/keyword.tsx
+++ b/src/pages/profile/keyword.tsx
@@ -9,14 +9,14 @@ export default function Keyword() {
   const { userInfo } = useGetProfile();
 
   useEffect(() => {
-    setKeywordList(userInfo?.keywords);
+    setKeywordList(userInfo?.keywords || []);
   }, [userInfo]);
 
   console.log(userInfo);
   const handleSubmit = async (e: any) => {
     let response;
     if (e.target.id === 'skip') {
-      response = await authApi.patchKeyword(userInfo?.keywords);
+      response = await authApi.patchKeyword(userInfo?.keywords || []);
     } else {
       response = await authApi.patchKeyword(keywordList);
     }

--- a/src/pages/profile/selling.tsx
+++ b/src/pages/profile/selling.tsx
@@ -1,9 +1,10 @@
-import Layout from '@components/common/Layout'
-import Modal from '@components/common/Modal'
-import Navigate from '@components/common/Navigate'
-import ArtItem from '@components/profile/ArtItem'
-import React, { useState } from 'react'
-import { Tab } from '@headlessui/react'
+import Layout from '@components/common/Layout';
+import Modal from '@components/common/Modal';
+import Navigate from '@components/common/Navigate';
+import ArtItem from '@components/profile/ArtItem';
+import React, { useState } from 'react';
+import { Tab } from '@headlessui/react';
+import useGetSellingArtWork from '@hooks/queries/useGetSellingArtWork';
 
 export default function Selling() {
   const [isModal, setIsModal] = useState<boolean>(false);
@@ -16,6 +17,8 @@ export default function Selling() {
   const handleAccept = () => {
     console.log('수정/삭제');
   };
+  const { sellingArtWork } = useGetSellingArtWork();
+  console.log(sellingArtWork);
   return (
     <Layout>
       <Modal


### PR DESCRIPTION
## 🧑‍💻 PR 내용

1. [instace 수정](https://github.com/Att-ies/frontend/commit/d133bd02414e88f14003f7521f01706af2fad72e)하였습니다.
- 중복하여 Authorization을 설정하는 setAuthorHeader, unsetAuthorHeader 함수 제거
- token을, interceptors.response에서 401로 올 경우 refreshtoken으로 재전송을 하기에, token 유무 검사는 없어도 된다고 생각하여 제거하였습니다.
- ...config.headers를 추가함으로써 앞으로 instance로 multipart도 전송할 수 있습니다. => 반 완료
- 위의 코드 변경 이후 토큰 검사가 정상 동작하였 확인하였습니다.
2. 판매 페이지 API, 작가 정보 수정 API, 취향 변경 API 구현하였습니다.

## 📸 스크린샷

스크린샷을 첨부해주세요.
