### PR TITLE
remote image에 next/image 사용

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -3,6 +3,9 @@
 module.exports = {
   reactStrictMode: true,
   swcMinify: true,
+  images: {
+    domains: ['atties-bucket.s3.ap-northeast-2.amazonaws.com'],
+  },
   async headers() {
     return [
       {

--- a/src/pages/profile/edit.tsx
+++ b/src/pages/profile/edit.tsx
@@ -51,7 +51,6 @@ export default function Edit() {
   }, [nickname]);
 
   useEffect(() => {
-    console.log(profile);
     if (!profile) return;
     setUserInfo(
       (prev) =>
@@ -154,6 +153,7 @@ export default function Edit() {
   };
 
   if (isLoading) return <Loader />;
+
   return (
     <Layout>
       <Navigate
@@ -171,12 +171,28 @@ export default function Edit() {
       />
       <label className="flex h-[150px] justify-center" htmlFor="image">
         {userInfo?.image ? (
-          <div className=" relative flex h-[99px] w-[99px] cursor-pointer items-center justify-center rounded-full border-2 border-[#999999] bg-[#FFFFFF]">
-            <img
+          <div className="relative flex h-[99px] w-[99px] cursor-pointer items-center justify-center rounded-full bg-[#FFFFFF]            ">
+            <Image
               src={userInfo?.image}
-              width="60"
-              height="0"
-              className="h-[99px] w-[99px] rounded-full"
+              className="rounded-full object-cover"
+              fill
+              alt="profile"
+            />
+            <div className="absolute right-0 bottom-0 flex h-[26px] w-[26px] items-center justify-center rounded-full bg-[#575757]">
+              <Image
+                src="/svg/icons/icon_camera.svg"
+                width="15"
+                height="0"
+                alt="image"
+              />
+            </div>
+          </div>
+        ) : data?.image ? (
+          <div className="relative flex h-[99px] w-[99px] cursor-pointer items-center justify-center rounded-full bg-[#FFFFFF]            ">
+            <Image
+              src={data?.image}
+              className="rounded-full object-cover"
+              fill
               alt="profile"
             />
             <div className="absolute right-0 bottom-0 flex h-[26px] w-[26px] items-center justify-center rounded-full bg-[#575757]">
@@ -316,7 +332,7 @@ export default function Edit() {
                 {...register('instagram')}
                 id="instagram"
                 defaultValue={userInfo?.instagram}
-                className="h-[30px] w-[calc(100%-32px)] indent-1 text-12 placeholder:text-[#999] "
+                className="h-[30px] w-[calc(100%-32px)] indent-1 text-12 placeholder:text-[#999]"
               />
             </div>
             <div className="flex items-center">

--- a/src/pages/profile/index.tsx
+++ b/src/pages/profile/index.tsx
@@ -140,7 +140,9 @@ export default function Profile() {
               )}
             </div>
             <div className="mr-3 flex flex-col text-[#FFFFFF]">
-              <span className="font-medium">{data?.nickname}님,</span>
+              <span className="font-medium">
+                {data?.nickname ? data?.nickname : '회원'}님,
+              </span>
               <span className="text-xs">아띠즈에 오신 걸 환영합니다.</span>
             </div>
             <div className="mr-3">

--- a/src/pages/profile/index.tsx
+++ b/src/pages/profile/index.tsx
@@ -112,7 +112,7 @@ export default function Profile() {
     <>
       <Layout>
         <Navigate
-          left_message=" "
+          left_message={false}
           message="프로필"
           right_message={
             <Image

--- a/src/pages/profile/index.tsx
+++ b/src/pages/profile/index.tsx
@@ -109,145 +109,147 @@ export default function Profile() {
 
   if (isLoading) return <Loader />;
   return (
-    <Layout>
-      <Navigate
-        left_message=" "
-        message="프로필"
-        right_message={
-          <Image
-            src="/svg/icons/icon_notification.svg"
-            alt="notification"
-            width="20"
-            height="0"
-          />
-        }
-        handleRightButton={handleRightButton}
-      />
-      <section>
-        <WelcomeBox>
-          <div className="flex h-[54px] w-[54px] items-center rounded-full bg-[#EDEDED]">
-            {data?.image ? (
-              <img src={data?.image} className="rounded-full" alt="profile" />
-            ) : (
-              <Image
-                src="/svg/icons/icon_user_gray.svg"
-                alt="user"
-                width="12"
-                height="0"
-                className="m-auto h-[27px] w-[27px] rounded-full bg-[#EDEDED]"
-              />
-            )}
-          </div>
-          <div className="mr-3 flex flex-col text-[#FFFFFF]">
-            <span className="font-medium">{data?.nickname}님,</span>
-            <span className="text-xs">아띠즈에 오신 걸 환영합니다.</span>
-          </div>
-          <div className="mr-3">
+    <>
+      <Layout>
+        <Navigate
+          left_message=" "
+          message="프로필"
+          right_message={
             <Image
-              src="/svg/icons/icon_pencil.svg"
-              alt="setting"
-              className="cursor-pointer"
-              onClick={handleEdit}
-              width="23"
+              src="/svg/icons/icon_notification.svg"
+              alt="notification"
+              width="20"
               height="0"
             />
-          </div>
-        </WelcomeBox>
-        {isUser && (
-          <div
-            onClick={handleRegister}
-            className="mt-4 flex cursor-pointer justify-between rounded border-[1px] border-brand p-4"
-          >
-            <div className="flex">
+          }
+          handleRightButton={handleRightButton}
+        />
+        <section>
+          <WelcomeBox>
+            <div className="flex h-[54px] w-[54px] items-center overflow-hidden rounded-full bg-[#EDEDED]">
+              {data?.image ? (
+                <Image src={data?.image} width="54" height="54" alt="profile" />
+              ) : (
+                <Image
+                  src="/svg/icons/icon_user_gray.svg"
+                  alt="user"
+                  width="12"
+                  height="0"
+                  className="m-auto h-[27px] w-[27px] rounded-full bg-[#EDEDED]"
+                />
+              )}
+            </div>
+            <div className="mr-3 flex flex-col text-[#FFFFFF]">
+              <span className="font-medium">{data?.nickname}님,</span>
+              <span className="text-xs">아띠즈에 오신 걸 환영합니다.</span>
+            </div>
+            <div className="mr-3">
               <Image
-                src="/svg/icons/icon_user.svg"
-                alt="avatar"
+                src="/svg/icons/icon_pencil.svg"
+                alt="setting"
+                className="cursor-pointer"
+                onClick={handleEdit}
                 width="23"
                 height="0"
               />
-              <span className="ml-3 text-14 leading-6">
-                작가 프로필 전환하기
-              </span>
             </div>
-            <Image
-              src="/svg/icons/icon_arrow_black.svg"
-              alt="arrow"
-              width="25"
-              height="0"
-            />
-          </div>
-        )}
-      </section>
-      <section className="flex justify-between gap-2">
-        {ActivityLists.map((activity: ActivityList) => (
-          <Activity
-            key={activity.id}
-            text={activity.text}
-            icon={activity.icon}
-            path={activity.path}
-          />
-        ))}
-      </section>
-      <DivisionBar className="my-5" />
-      <section className="my-4">
-        <div className="relative my-4">
-          <span className="text-14 font-bold text-[#191919]">
-            취향 목록
-            {data?.keywords?.length && (
-              <Image
-                src="/svg/icons/icon_pencil_black.svg"
-                alt="edit_keywords"
-                width="18"
-                height="0"
-                className="absolute left-[4rem] top-1 cursor-pointer"
-                onClick={() => {
-                  router.push('/profile/keyword');
-                }}
-              />
-            )}
-          </span>
-        </div>
-        {data?.keywords?.length ? (
-          <div className="mb-8 flex flex-wrap">
-            {data?.keywords?.map((keyword: string) => (
-              <span
-                className="mr-2 mb-1 rounded-[19px] border-[1px] border-[#DBDBDB] px-3 py-1 text-14 text-[#767676] last:mr-0 "
-                key={keyword}
-              >
-                {keyword}
-              </span>
-            ))}
-          </div>
-        ) : (
-          <div className="mt-6 mb-12 flex justify-center text-center">
-            <button
-              onClick={handleKeywords}
-              className="flex h-[36px] w-[100px] items-center justify-center rounded-[19px] border-[1px] border-brand text-xs text-brand"
+          </WelcomeBox>
+          {isUser && (
+            <div
+              onClick={handleRegister}
+              className="mt-4 flex cursor-pointer justify-between rounded border-[1px] border-brand p-4"
             >
-              <div>
+              <div className="flex">
                 <Image
-                  src="/svg/icons/icon_plus_pink.svg"
-                  alt="plus"
-                  width="10"
+                  src="/svg/icons/icon_user.svg"
+                  alt="avatar"
+                  width="23"
                   height="0"
                 />
+                <span className="ml-3 text-14 leading-6">
+                  작가 프로필 전환하기
+                </span>
               </div>
-              <div>취향분석</div>
-            </button>
+              <Image
+                src="/svg/icons/icon_arrow_black.svg"
+                alt="arrow"
+                width="25"
+                height="0"
+              />
+            </div>
+          )}
+        </section>
+        <section className="flex justify-between gap-2">
+          {ActivityLists.map((activity: ActivityList) => (
+            <Activity
+              key={activity.id}
+              text={activity.text}
+              icon={activity.icon}
+              path={activity.path}
+            />
+          ))}
+        </section>
+        <DivisionBar className="my-5" />
+        <section className="my-4">
+          <div className="relative my-4">
+            <span className="text-14 font-bold text-[#191919]">
+              취향 목록
+              {data?.keywords?.length && (
+                <Image
+                  src="/svg/icons/icon_pencil_black.svg"
+                  alt="edit_keywords"
+                  width="18"
+                  height="0"
+                  className="absolute left-[4rem] top-1 cursor-pointer"
+                  onClick={() => {
+                    router.push('/profile/keyword');
+                  }}
+                />
+              )}
+            </span>
           </div>
-        )}
-      </section>
-      <DivisionBar className="my-5" />
-      <section>
-        {SettingLists.map((setting: SettingList) => (
-          <SettingItem
-            key={setting.id}
-            text={setting.text}
-            path={setting.path}
-          />
-        ))}
-      </section>
+          {data?.keywords?.length ? (
+            <div className="mb-8 flex flex-wrap">
+              {data?.keywords?.map((keyword: string) => (
+                <span
+                  className="mr-2 mb-1 rounded-[19px] border-[1px] border-[#DBDBDB] px-3 py-1 text-14 text-[#767676] last:mr-0 "
+                  key={keyword}
+                >
+                  {keyword}
+                </span>
+              ))}
+            </div>
+          ) : (
+            <div className="mt-6 mb-12 flex justify-center text-center">
+              <button
+                onClick={handleKeywords}
+                className="flex h-[36px] w-[100px] items-center justify-center rounded-[19px] border-[1px] border-brand text-xs text-brand"
+              >
+                <div>
+                  <Image
+                    src="/svg/icons/icon_plus_pink.svg"
+                    alt="plus"
+                    width="10"
+                    height="0"
+                  />
+                </div>
+                <div>취향분석</div>
+              </button>
+            </div>
+          )}
+        </section>
+        <DivisionBar className="my-5" />
+        <section>
+          {SettingLists.map((setting: SettingList) => (
+            <SettingItem
+              key={setting.id}
+              text={setting.text}
+              path={setting.path}
+            />
+          ))}
+        </section>
+      </Layout>
       <Tab />
-    </Layout>
+    </>
   );
 }


### PR DESCRIPTION
## 🧑‍💻 PR 내용
next.config.js 에 domain을 추가해서 서버로부터 받아온 remote image에도 next/image를 사용할 수 있습니다. 
프로필 수정페이지에서 data -> userInfo 복사후 미리보기를 보여주면 next/image에서 받아오지를 못해서 케이스를 좀더 나누어서 구현했습니다. 

사진있을때 회색 border가 살짝 가려지는데 overflow-hidden으로 사진이 벗어난 부분을 가리면 카메라버튼도 같이 사라져서 사진이 있을때는 border가 없는것으로 구현했습니다.

순서대로 
1. 프로필 페이지
2. 프로필 수정 페이지
3. 프로필 수정 페이지에서 사진 변경후 
입니다. 
4. 프로필 사진 없는 경우 

생각해보니 현재 기본프로필로 수정은 불가능한데 이후에 추가하면 좋을거 같습니다. 
## 📸 스크린샷
![캡처_2023_01_25_14_29_40_736](https://user-images.githubusercontent.com/92621861/214488213-eb6fcade-ad63-4504-948f-148278363023.png)
![캡처_2023_01_25_14_29_49_84](https://user-images.githubusercontent.com/92621861/214488218-0b6606b4-3de7-4a11-bec6-036eab76d479.png)
![캡처_2023_01_25_14_30_03_545](https://user-images.githubusercontent.com/92621861/214488225-23fe1e3b-5004-489c-981a-650e48e19188.png)
<img width="278" alt="image" src="https://user-images.githubusercontent.com/92621861/214489533-6619323b-74cc-44c7-9fae-9bbad43e067d.png">
