### PR TITLE
디자인 수정(반응형으로)

### DIFF
--- a/src/components/common/Layout.tsx
+++ b/src/components/common/Layout.tsx
@@ -13,7 +13,7 @@ interface LayoutProps {
 
 export default function Layout({ children }: LayoutProps) {
   return (
-    <LayoutBox className=" relative h-full w-full max-w-[420px] overflow-y-scroll  bg-white px-4">
+    <LayoutBox className="relative h-full w-full max-w-[420px] overflow-y-scroll  bg-white px-4">
       {children}
     </LayoutBox>
   );

--- a/src/components/common/Layout.tsx
+++ b/src/components/common/Layout.tsx
@@ -13,7 +13,7 @@ interface LayoutProps {
 
 export default function Layout({ children }: LayoutProps) {
   return (
-    <LayoutBox className="relative h-[calc(100vh-80px)] w-full overflow-scroll px-6 py-[45px]">
+    <LayoutBox className="bg-grey-1 relative h-full w-full max-w-[420px] overflow-y-scroll border px-4">
       {children}
     </LayoutBox>
   );

--- a/src/components/common/Layout.tsx
+++ b/src/components/common/Layout.tsx
@@ -13,7 +13,7 @@ interface LayoutProps {
 
 export default function Layout({ children }: LayoutProps) {
   return (
-    <LayoutBox className="bg-grey-1 relative h-full w-full max-w-[420px] overflow-y-scroll border px-4">
+    <LayoutBox className="relative h-full w-full max-w-[420px] overflow-y-scroll border px-4">
       {children}
     </LayoutBox>
   );

--- a/src/components/common/Layout.tsx
+++ b/src/components/common/Layout.tsx
@@ -13,7 +13,7 @@ interface LayoutProps {
 
 export default function Layout({ children }: LayoutProps) {
   return (
-    <LayoutBox className="relative h-full w-full max-w-[420px] overflow-y-scroll border px-4">
+    <LayoutBox className=" relative h-full w-full max-w-[420px] overflow-y-scroll  bg-white px-4">
       {children}
     </LayoutBox>
   );

--- a/src/components/common/Tab.tsx
+++ b/src/components/common/Tab.tsx
@@ -35,10 +35,10 @@ interface DefaultProps {
 }
 
 const TabBox = tw.footer<DefaultProps>`
- fixed bottom-0 bg-white w-full flex justify-center z-50 py-2 inset-x-0 m-auto
+ absolute bottom-0 bg-white max-w-[420px] flex justify-center z-50 py-2 inset-x-0 m-auto px-3
 `;
 
-const TabList = tw.div<DefaultProps>`flex w-[327px]`;
+const TabList = tw.div<DefaultProps>`flex w-full`;
 
 interface TabItemProps {
   id: number;

--- a/src/components/common/Tab.tsx
+++ b/src/components/common/Tab.tsx
@@ -1,6 +1,6 @@
-import Image from 'next/image'
-import tw from 'tailwind-styled-components'
-import { useRouter } from 'next/router'
+import Image from 'next/image';
+import tw from 'tailwind-styled-components';
+import { useRouter } from 'next/router';
 
 const TABLIST = [
   {
@@ -35,7 +35,7 @@ interface DefaultProps {
 }
 
 const TabBox = tw.footer<DefaultProps>`
- fixed bottom-0 bg-white w-full max-w-[375px] flex justify-center z-50 py-4 inset-x-0 m-auto
+ fixed bottom-0 bg-white w-full flex justify-center z-50 py-2 inset-x-0 m-auto
 `;
 
 const TabList = tw.div<DefaultProps>`flex w-[327px]`;

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -20,7 +20,7 @@ export default function App({ Component, pageProps }: AppProps) {
   // }, [router]);
 
   return (
-    <div className="bg-grey-2 flex h-screen w-screen justify-center">
+    <div className="flex h-screen w-screen justify-center bg-slate-50">
       <Head>
         <link rel="shortcut icon" href="/static/favicon.ico" />
       </Head>

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -20,7 +20,7 @@ export default function App({ Component, pageProps }: AppProps) {
   // }, [router]);
 
   return (
-    <div className="relative mx-auto h-screen w-full max-w-[375px] overflow-y-auto border border-gray-500 font-Pretendard">
+    <div className="bg-grey-2 flex h-screen w-screen justify-center">
       <Head>
         <link rel="shortcut icon" href="/static/favicon.ico" />
       </Head>

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -6,7 +6,6 @@ import { Provider } from 'react-redux';
 import { PersistGate } from 'redux-persist/integration/react';
 import { persistStore } from 'redux-persist';
 import { QueryClient, QueryClientProvider } from 'react-query';
-import { ReactQueryDevtools } from 'react-query/devtools';
 
 import type { AppProps } from 'next/app';
 const queryClient = new QueryClient();

--- a/src/pages/begin.tsx
+++ b/src/pages/begin.tsx
@@ -19,7 +19,7 @@ const Title = tw.p`
 text-20 font-bold mt-16
 `;
 const Content = tw.p<defaultProps>`text-10 text-[#767676] mt-2 leading-4`;
-const Line = tw.span``;
+const Line = tw.p``;
 
 export default function Begin() {
   const swiperRef = useRef<any>(null);
@@ -104,7 +104,7 @@ export default function Begin() {
               <Title>채팅으로 작가와 컬렉터가 소통해요</Title>
               <Content>
                 <Line>아티스트와 컬렉터가 대화할 수 있는 </Line>
-                <Line>현대미술의 장점! 채팅으로 컬렉터분들과 소통해요.</Line>
+                <Line>현대미술의 장점! 채팅으로 함께 소통해요.</Line>
               </Content>
             </div>
             <div className="mt-6 flex justify-center space-x-3">


### PR DESCRIPTION
## 🧑‍💻 PR 내용

기존에 휴대폰으로 보았을 때 화면 짤림 현상 + 경계가 아닌 곳에 레이아웃이 있는 현상이 있어 수정하였습니다.
![image](https://user-images.githubusercontent.com/62178788/214724545-365483d5-0bcc-42a9-8408-ffd67935f55e.png)
h-screen, w-screen 함으로써 휴대폰 하면 크기에 맞게 크기가 맞춰집니다.

![image](https://user-images.githubusercontent.com/62178788/214724689-d947bc09-25b9-4f4a-8df6-242dfe98a5c0.png)
Layout의 최대 사이즈인 420이하까지는 바깥의 다른 배경색이 안보이고 화면이 휴대폰 사이즈에 맞게 확장이 되고, 420이 넘어가면 배경색(임시로 bg-slate-50 해두었습니다)으로 채워지게 됩니다.

## 📸 스크린샷

![녹화_2023_01_26_09_18_52_157](https://user-images.githubusercontent.com/62178788/214724318-6a2c3837-c06a-4562-bfbd-323669ef9149.gif)

