### PR TITLE
회원가입 약관 동의 수정

### DIFF
--- a/public/svg/icons/icon_arrow_down.svg
+++ b/public/svg/icons/icon_arrow_down.svg
@@ -1,3 +1,3 @@
-<svg width="19" height="20" viewBox="0 0 19 20" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M15.0413 9.99992L9.49967 15.8333L3.95801 9.99992" stroke="#999999" stroke-width="1.27644" stroke-linecap="round" stroke-linejoin="round"/>
+<svg width="16" height="9" viewBox="0 0 16 9" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M15 1L8 8L1 1" stroke="#999999" stroke-width="1.91467" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>

--- a/src/features/user/userSlice.ts
+++ b/src/features/user/userSlice.ts
@@ -1,7 +1,8 @@
-import { createSlice, PayloadAction } from '@reduxjs/toolkit'
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
 interface UserState extends User, Artist {
-  isApprovePromotion: boolean;
+  isApproveSMSPromotion: boolean;
+  isApproveEmailPromotion: boolean;
   isArtist: boolean;
   keywords: string[]; //user
 }
@@ -21,7 +22,8 @@ const initialState: UserState = {
   instagram: '',
   behance: '',
 
-  isApprovePromotion: false,
+  isApproveSMSPromotion: false,
+  isApproveEmailPromotion: false,
   isArtist: false,
 };
 
@@ -49,12 +51,19 @@ const userSlice = createSlice({
       instagram: action.payload.instagram,
       behance: action.payload.behance,
     }),
-    setIsApprovePromotion: (
+    setIsApproveSMSPromotion: (
       state: UserState,
       action: PayloadAction<boolean>,
     ) => ({
       ...state,
-      isApprovePromotion: action.payload,
+      isApproveSMSPromotion: action.payload,
+    }),
+    setIsApproveEmailPromotion: (
+      state: UserState,
+      action: PayloadAction<boolean>,
+    ) => ({
+      ...state,
+      isApproveEmailPromotion: action.payload,
     }),
     setIsArtist: (state: UserState, action: PayloadAction<boolean>) => ({
       ...state,
@@ -66,7 +75,8 @@ const userSlice = createSlice({
 export const {
   setUserInfo,
   setKeywords,
-  setIsApprovePromotion,
+  setIsApproveSMSPromotion,
+  setIsApproveEmailPromotion,
   setArtistInfo,
   setIsArtist,
 } = userSlice.actions;

--- a/src/pages/auth/join01.tsx
+++ b/src/pages/auth/join01.tsx
@@ -1,15 +1,15 @@
-import Button from '@components/common/Button'
-import CheckBox from '@components/common/Checkbox'
-import Layout from '@components/common/Layout'
-import Navigate from '@components/common/Navigate'
-import arrowBtn from '@public/svg/icons/icon_arrow.svg'
-import Image from 'next/image'
-import tw from 'tailwind-styled-components'
-import { useAppDispatch } from '@features/hooks'
-import { setIsApprovePromotion } from '@features/user/userSlice'
-import { useRouter } from 'next/router'
-import { useState } from 'react'
-import { useForm } from 'react-hook-form'
+import Button from '@components/common/Button';
+import CheckBox from '@components/common/Checkbox';
+import Layout from '@components/common/Layout';
+import Navigate from '@components/common/Navigate';
+import arrowBtn from '@public/svg/icons/icon_arrow.svg';
+import Image from 'next/image';
+import tw from 'tailwind-styled-components';
+import { useAppDispatch } from '@features/hooks';
+import { setIsApproveEmailPromotion, setIsApproveSMSPromotion } from '@features/user/userSlice';
+import { useRouter } from 'next/router';
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
 
 interface DefaultProps {
   [key: string]: any;
@@ -17,6 +17,10 @@ interface DefaultProps {
 
 const CheckBoxList = tw.li<DefaultProps>`
 pb-[18px] flex justify-between
+`;
+
+const TermButton = tw.div<DefaultProps>`
+flex justify-center items-center cursor-pointer
 `;
 
 export default function Join01() {
@@ -30,19 +34,21 @@ export default function Join01() {
   };
 
   const [checkedTerm, setCheckedTerm] = useState<string[]>([]);
+  const [isOpen, setIsOpen] = useState<boolean>(false);
 
   const onCheckedAll = (checked: boolean): void => {
     if (checked) {
-      setCheckedTerm(() => ['term1', 'term2', 'term3', 'term4']);
+      setCheckedTerm(() => ['term1', 'term2', 'term4', 'term5']);
     } else if (
       (!checked && checkedTerm.includes('term1')) ||
       (!checked && checkedTerm.includes('term2')) ||
-      (!checked && checkedTerm.includes('term3')) ||
-      (!checked && checkedTerm.includes('term4'))
+      (!checked && checkedTerm.includes('term4')) ||
+      (!checked && checkedTerm.includes('term5'))
     ) {
       setCheckedTerm(() => []);
     }
   };
+
   const onChecked = (checked: boolean, id: string): void => {
     if (checked) {
       setCheckedTerm(() => [...checkedTerm, id]);
@@ -51,21 +57,30 @@ export default function Join01() {
     }
   };
 
+  const onCheckedPromotion = (checked: boolean): void => {
+    if (checked) {
+      setCheckedTerm(() => [...checkedTerm, 'term4', 'term5']);
+    } else if (!checked) {
+      const values = ['term4', 'term5'];
+      setCheckedTerm(() =>
+        checkedTerm.filter((el: string) => !values.includes(el)),
+      );
+    }
+  };
+
   const dispatch = useAppDispatch();
 
   const { handleSubmit } = useForm();
+
   const onSubmit = () => {
     if (checkedTerm.includes('term4')) {
-      dispatch(setIsApprovePromotion(true));
-    } else {
-      dispatch(setIsApprovePromotion(false));
+      dispatch(setIsApproveSMSPromotion(true));
+    }
+    if (checkedTerm.includes('term5')) {
+      dispatch(setIsApproveEmailPromotion(true));
     }
 
-    if (
-      checkedTerm.includes('term1') &&
-      checkedTerm.includes('term2') &&
-      checkedTerm.includes('term3')
-    ) {
+    if (checkedTerm.includes('term1') && checkedTerm.includes('term2')) {
       router.push('/auth/join02');
     }
   };
@@ -96,14 +111,14 @@ export default function Join01() {
                 isChecked={checkedTerm.includes('term1')}
                 handler={(e) => onChecked(e.target.checked, e.target.id)}
               />
-              <button>
+              <TermButton onClick={() => router.push('/')}>
                 <Image
-                  src={arrowBtn}
+                  src="/svg/icons/icon_arrow.svg"
                   alt="arrowBtn"
                   width={7}
-                  height={14}
+                  height={0}
                 ></Image>
-              </button>
+              </TermButton>
             </CheckBoxList>
             <CheckBoxList>
               <CheckBox
@@ -112,54 +127,74 @@ export default function Join01() {
                 isChecked={checkedTerm.includes('term2')}
                 handler={(e) => onChecked(e.target.checked, e.target.id)}
               />
-              <button>
+              <TermButton>
                 <Image
-                  src={arrowBtn}
+                  src="/svg/icons/icon_arrow.svg"
                   alt="arrowBtn"
                   width={7}
-                  height={14}
+                  height={0}
                 ></Image>
-              </button>
+              </TermButton>
             </CheckBoxList>
-            <CheckBoxList>
+            <CheckBoxList className="pb-0">
               <CheckBox
                 id="term3"
-                label="위치정보 이용약관에 동의(필수)"
-                isChecked={checkedTerm.includes('term3')}
-                handler={(e) => onChecked(e.target.checked, e.target.id)}
+                label="아띠즈 마케팅 활용 동의 및 광고 수신 동의(선택)"
+                isChecked={
+                  checkedTerm.includes('term4') && checkedTerm.includes('term5')
+                }
+                handler={(e) => onCheckedPromotion(e.target.checked)}
               />
-              <button>
+              <TermButton
+                className={`${isOpen && 'rotate-90 transform transition'}`}
+                onClick={() => {
+                  if (!isOpen) {
+                    setIsOpen(true);
+                  } else {
+                    setIsOpen(false);
+                  }
+                }}
+              >
                 <Image
-                  src={arrowBtn}
+                  src="/svg/icons/icon_arrow.svg"
                   alt="arrowBtn"
                   width={7}
-                  height={14}
+                  height={0}
                 ></Image>
-              </button>
+              </TermButton>
             </CheckBoxList>
-            <CheckBoxList>
-              <CheckBox
-                id="term4"
-                label="아띠즈 이벤트와 프로모션 수신 동의(선택)"
-                isChecked={checkedTerm.includes('term4')}
-                handler={(e) => onChecked(e.target.checked, e.target.id)}
-              />
-              <button>
-                <Image
-                  src={arrowBtn}
-                  alt="arrowBtn"
-                  width={7}
-                  height={14}
-                ></Image>
-              </button>
-            </CheckBoxList>
+            {isOpen && (
+              <div>
+                <p className="w-full px-7 py-2 text-10 text-[#191919]">
+                  서비스와 관련된 신상품 소식, 이벤트 안내, 고객 혜택 등 다양한
+                  정보를 제공합니다.
+                </p>
+                <CheckBoxList className="ml-7 pb-2">
+                  <CheckBox
+                    id="term4"
+                    label="SMS 수신 동의(선택)"
+                    isChecked={checkedTerm.includes('term4')}
+                    handler={(e) => {
+                      console.log(e);
+                      onChecked(e.target.checked, e.target.id);
+                    }}
+                  />
+                </CheckBoxList>
+                <CheckBoxList className="ml-7">
+                  <CheckBox
+                    id="term5"
+                    label="E-Mail 수신 동의(선택)"
+                    isChecked={checkedTerm.includes('term5')}
+                    handler={(e) => onChecked(e.target.checked, e.target.id)}
+                  />
+                </CheckBoxList>
+              </div>
+            )}
           </ul>
         </div>
         <Button
           disabled={
-            checkedTerm.includes('term1') &&
-            checkedTerm.includes('term2') &&
-            checkedTerm.includes('term3')
+            checkedTerm.includes('term1') && checkedTerm.includes('term2')
               ? false
               : true
           }

--- a/src/pages/profile/register/index.tsx
+++ b/src/pages/profile/register/index.tsx
@@ -1,3 +1,4 @@
+import profileApi from '@apis/profile/profileApi';
 import Layout from '@components/common/Layout';
 import Navigate from '@components/common/Navigate';
 import Image from 'next/image';
@@ -5,22 +6,13 @@ import React, { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
 import { useForm } from 'react-hook-form';
 import { getToken, setToken } from '@utils/localStorage/token';
-import profileApi from '@apis/profile/profileApi';
+import { formatBytes } from '@utils/formatBytes';
 
 interface FileForm {
   file: any;
   fileName: string;
   fileSize: string;
 }
-
-const formatBytes = (bytes: number, decimals = 1) => {
-  if (!bytes) return '0';
-  const k = 1024;
-  const dm = decimals < 0 ? 0 : decimals;
-  const sizes = ['Bytes', 'KB', 'MB'];
-  const i = Math.floor(Math.log(bytes) / Math.log(k));
-  return `${parseFloat((bytes / Math.pow(k, i)).toFixed(dm))} ${sizes[i]}`;
-};
 
 export default function Register() {
   const router = useRouter();


### PR DESCRIPTION
## 🧑‍💻 PR 내용

광고 동의가 두가지로 나누어 진 점을 반영해서 페이지 수정을 완료했습니다.

약관은 처음에 디자인 팀에서 정해준 방식으로는 약관 페이지로의 이동이었는데 이 부분은 약관 페이지로 이동한 후 다시 돌아왔을 경우  중간에 체크해놓은 사항들이 초기화 될 수 있는점, 페이지 전환으로 인한 불필요한 리소스 사용을 방지하기 위해, 모달 컴포넌트를 띄워주는 것이 좋을 것 같아 수정 요청 드렸습니다. 디자인 나오는 대로 구현하도록 하겠습니다.

광고 동의가 두가지로 나누어 졌기 때문에 redux로 관리하던 광고 동의 상태를 SMS, Email 두개의 상태로 분리했습니다.

작가 등록 부분에서 유틸로 빼놓았던 formatBytes 함수를 사용하도록 했습니다.

레이아웃 수정으로 인해 버튼 크기가 달라진 점은 Peter님이 수정하기로 했습니다.

## 📸 스크린샷


![녹화_2023_01_26_14_05_33_880](https://user-images.githubusercontent.com/79186378/214764019-81964a69-b0a5-48f6-8642-49223c2c7580.gif)
