### PR TITLE
전시작품 전체보기 페이지 무한스크롤 구현

### DIFF
--- a/src/apis/home/homeApi.ts
+++ b/src/apis/home/homeApi.ts
@@ -1,10 +1,14 @@
 import instance from '@apis/_axios/instance';
+
 import { CustomizeArtwork } from './homeApi.type';
 
 export class HomeApi {
-  async getCustomizedArtWork(): Promise<CustomizeArtwork> {
+  async getCustomizedArtWork(
+    page: number,
+    limit: number,
+  ): Promise<CustomizeArtwork> {
     const { data } = await instance(
-      '/members/customized-artworks?page=1&limit=5',
+      `/members/customized-artworks?page=${page}&limit=${limit}`,
     );
     return data;
   }

--- a/src/hooks/queries/useGetCustomizedArtWork.ts
+++ b/src/hooks/queries/useGetCustomizedArtWork.ts
@@ -2,8 +2,8 @@ import homeApi from '@apis/home/homeApi';
 import { CustomizeArtwork } from '@apis/home/homeApi.type';
 import { useQuery } from 'react-query';
 
-export default function useGetCustomizedArtWork() {
+export default function useGetCustomizedArtWork(page: number, limit: number) {
   return useQuery<CustomizeArtwork, Error>('useCustomizedArtWork', () =>
-    homeApi.getCustomizedArtWork(),
+    homeApi.getCustomizedArtWork(page, limit),
   );
 }

--- a/src/hooks/queries/useGetInfiniteArtWork.ts
+++ b/src/hooks/queries/useGetInfiniteArtWork.ts
@@ -1,0 +1,42 @@
+import homeApi from '@apis/home/homeApi';
+import { useInfiniteQuery } from 'react-query';
+
+interface KeywordArtwork {
+  id: string;
+  image: string;
+  title: string;
+  education: string;
+}
+
+interface InfiniteQueryProps {
+  artworks: KeywordArtwork[];
+  current_page: number;
+  nextPage: boolean;
+}
+
+export const useGetInfiniteArtWork = () => {
+  const getArtWork = async ({ pageParam = 1 }): Promise<InfiniteQueryProps> => {
+    const data = await homeApi.getCustomizedArtWork(pageParam, 20);
+    const { artworks, nextPage } = data;
+    return {
+      artworks,
+      current_page: pageParam,
+      nextPage,
+    };
+  };
+
+  const { data, fetchNextPage, isSuccess, hasNextPage } = useInfiniteQuery(
+    ['useInfiniteArtWork'],
+    getArtWork,
+    {
+      getNextPageParam: (lastPage: InfiniteQueryProps) => {
+        if (lastPage.nextPage) return lastPage.current_page + 1;
+        return undefined;
+      },
+      retry: false,
+      refetchOnWindowFocus: false,
+    },
+  );
+
+  return { data, fetchNextPage, hasNextPage };
+};

--- a/src/hooks/queries/useGetInfiniteArtWork.ts
+++ b/src/hooks/queries/useGetInfiniteArtWork.ts
@@ -25,7 +25,7 @@ export const useGetInfiniteArtWork = () => {
     };
   };
 
-  const { data, fetchNextPage, isSuccess, hasNextPage } = useInfiniteQuery(
+  const { data, fetchNextPage, hasNextPage } = useInfiniteQuery(
     ['useInfiniteArtWork'],
     getArtWork,
     {

--- a/src/pages/home/index.tsx
+++ b/src/pages/home/index.tsx
@@ -96,7 +96,7 @@ const DUMP_AFTER_AUCTION_LIST = makeThreeEach(DUMP_PREV_AUCTION_LISTS);
 export default function Home() {
   const router = useRouter();
 
-  const { data: customizedArtwork } = useGetCustomizedArtWork();
+  const { data: customizedArtwork } = useGetCustomizedArtWork(1, 5);
   const { data: userInfo } = useGetProfile();
   return (
     <>
@@ -142,7 +142,7 @@ export default function Home() {
             navigation
             scrollbar={{ draggable: true }}
             spaceBetween={2}
-            slidesPerView={2}
+            slidesPerView={2.1}
             autoplay={{ delay: 5000, disableOnInteraction: false }}
           >
             {customizedArtwork?.artworks?.map(

--- a/src/pages/home/view.tsx
+++ b/src/pages/home/view.tsx
@@ -1,63 +1,97 @@
 import Layout from '@components/common/Layout';
-import React from 'react';
-import { useRouter } from 'next/router';
-import ExhibitionItem from '@components/home/ExhibitionItem';
 import Navigate from '@components/common/Navigate';
+import ExhibitionItem from '@components/home/ExhibitionItem';
+import useGetProfile from '@hooks/queries/useGetProfile';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useGetInfiniteArtWork } from '@hooks/queries/useGetInfiniteArtWork';
+import { useRouter } from 'next/router';
 
-const DUMP_ART_LISTS = [
-  {
-    image: '/svg/example/exhibition.svg',
-    education: '홍익대학교',
-    title: '작품이름',
-    id: '1',
-  },
-  {
-    image: '/svg/example/detail.svg',
-    education: '서울대학교',
-    title: '작품이름',
-    id: '2',
-  },
-  {
-    image: '/svg/example/exhibition.svg',
-    education: '연세대학교',
-    title: '작품이름',
-    id: '3',
-  },
-  {
-    image: '/svg/example/detail.svg',
-    education: '고려대학교',
-    title: '작품이름',
-    id: '4',
-  },
-  {
-    image: '/svg/example/exhibition.svg',
-    education: '건국대학교',
-    title: '작품이름',
-    id: '5',
-  },
-];
+interface ARTLISTS {
+  id?: number;
+  title: string;
+  education: string;
+  image: string;
+}
 
 export default function View() {
   const router = useRouter();
+
+  const target = useRef<HTMLDivElement | null>(null);
+  const [isLoaded, setIsLoaded] = useState<boolean>(false);
+
+  const { data: userInfo } = useGetProfile();
+  const { data, hasNextPage, fetchNextPage } = useGetInfiniteArtWork();
+
+  const artworkLists = useMemo(
+    () => data?.pages.flatMap((page) => page.artworks),
+    [data?.pages],
+  );
+
+  const getMoreArtWork = async () => {
+    setIsLoaded(true);
+    if (hasNextPage) {
+      await fetchNextPage();
+    }
+    setIsLoaded(false);
+  };
+
+  const onIntersect = useCallback(
+    async (
+      [entry]: IntersectionObserverEntry[],
+      observer: IntersectionObserver,
+    ) => {
+      if (entry.isIntersecting && !isLoaded) {
+        observer.unobserve(entry.target);
+        await getMoreArtWork();
+        observer.observe(entry.target);
+      }
+    },
+    [fetchNextPage, hasNextPage],
+  );
+
+  useEffect(() => {
+    let observer;
+    if (target) {
+      observer = new IntersectionObserver(onIntersect, {
+        threshold: 0.1,
+      });
+      observer.observe(target.current);
+    }
+    return () => observer && observer.disconnect();
+  }, [onIntersect]);
+
   return (
     <Layout>
       <Navigate isRightButton={false} />
       <div>
         <p className="text-[14px] font-semibold text-[#767676]">
-          영서님 취향의
+          {userInfo?.nickname}님 취향의
         </p>
         <p className="text-[20px] font-bold text-[#191919]">이번 주 전시작품</p>
       </div>
-      <div className="flex flex-wrap gap-x-2 gap-y-4">
-        {DUMP_ART_LISTS.map((art, idx) => (
+      <div className="mt-6 flex w-full flex-wrap justify-center gap-y-5 gap-x-5">
+        {artworkLists?.map((art, idx) => (
           <ExhibitionItem
+            key={idx}
             src={art.image}
             education={art.education}
             title={art.title}
-            key={idx}
             id={art.id}
           />
         ))}
+        <div ref={target} className="flex h-[100px] w-full justify-center">
+          {isLoaded && (
+            <div className="mt-5 flex h-[30px] items-center justify-center">
+              <div className="grid gap-2">
+                <div className="flex items-center justify-center space-x-2">
+                  <div className="h-3 w-3 animate-bounce1 rounded-full bg-brand"></div>
+                  <div className="h-3 w-3 animate-bounce2 rounded-full bg-brand"></div>
+                  <div className="h-3 w-3 animate-bounce3 rounded-full bg-brand"></div>
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
       </div>
     </Layout>
   );


### PR DESCRIPTION
## 🧑‍💻 PR 내용

react-query의 useInfiniteQuery를 사용하여 useGetInfiniteArtWork 무한 스크롤 훅을 구현하였습니다.

useGetInfiniteArtWork 훅 내에서는 전시작품의 목록을 불러오는 API를 통해 받아온 작품배열, 페이지의 끝을 나타내는 boolean 값과 함께 현재 페이지를 가리키는 변수를 담아 리턴하는 getArtWork 함수가 존재합니다.
useInfiniteQuery의 첫번째 파라미터로 쿼리 키를 넣어주고 두번째 파라미터로 getArtWork 함수를 넣어줍니다.
getNextPageParam의 lastPage는 직전에 호출한 콜백함수의 리턴값입니다. 따라서 해당 리턴값에서 다음페이지가 있다면 현재페이지 + 1을 해줍니다.

view 페이지 내에서 useRef를 통해 Intersection Observer가 관찰할 Element를 연결하고 해당 ref가 눈에 보이면 즉, intersecting되면 onIntersect 콜백함수를 실행하도록 합니다.

전시작품 목록 불러오는 API의  페이지와 개수를 하드코딩한 것을 수정했습니다.

## 📸 스크린샷
![녹화_2023_01_27_17_58_11_272](https://user-images.githubusercontent.com/79186378/215053712-b276f29d-a8d4-4c3f-8c9a-27f382b5b55d.gif)


