### PR TITLE
전시회 페이지 디자인 수정

### DIFF
--- a/src/components/exhibition/Modal.tsx
+++ b/src/components/exhibition/Modal.tsx
@@ -19,12 +19,12 @@ interface DefaultProps {
 }
 
 const ModalInner = tw.div<DefaultProps>`
-absolute w-[327px] h-[280px] m-auto rounded-[8px] backdrop-blur-[25.5px] p-5 transition  ${(
+absolute w-full bottom-0 h-auto m-auto rounded-[8px] backdrop-blur-[25.5px] p-5 transition  ${(
   p,
 ) =>
   p.$open
-    ? 'bg-gradient-to-r from-[#FFFFFF]/[.16] to-[#FFFFFF]/[.46] translate-y-[-250px]'
-    : 'bg-gradient-to-b from-[#FFFFFF]/[.16] to-[#FFFFFF]/[.46] translate-y-[120px] text-[#191919]/40'}
+    ? 'bg-gradient-to-r from-[#FFFFFF]/[.16] to-[#FFFFFF]/[.46] translate-y-[calc(-30vh)]'
+    : 'bg-gradient-to-b from-[#FFFFFF]/[.16] to-[#FFFFFF]/[.46] translate-y-[120px]'}
 `;
 const ModalHeader = tw.div<DefaultProps>`
 text-[#424242] text-20 flex justify-between font-bold `;
@@ -51,34 +51,38 @@ export default function Modal({
   ...rest
 }: ModalProps) {
   return (
-    <ModalInner {...rest}>
+    <>
       {!isOpen && (
-        <Image
-          alt="swipe"
-          src="/svg/icons/icon_swipe_arrow.svg"
-          width={20}
-          height={20}
-          className="absolute top-[-30px] right-[150px] cursor-pointer"
-          onClick={handleSwipeArrow}
-        />
+        <div className="absolute bottom-[170px] flex h-auto w-[22px] justify-center">
+          <Image
+            alt="swipe"
+            src="/svg/icons/icon_swipe_arrow.svg"
+            width={20}
+            height={20}
+            className="cursor-pointer"
+            onClick={handleSwipeArrow}
+          />
+        </div>
       )}
-      <ModalHeader>
-        <span>{title}</span>
-        <Image
-          src="/svg/icons/icon_grayClose.svg"
-          alt="close"
-          width={20}
-          height={20}
-          onClick={onCloseModal}
-          className="cursor-pointer"
-        />
-      </ModalHeader>
-      <MajorDiv>{major}</MajorDiv>
-      <DescriptionDiv>{description}</DescriptionDiv>
-      <div className="flex w-full justify-evenly pt-4">
-        <ModalButton onClick={handleLeftButton}>작품 더보기</ModalButton>
-        <ModalButton onClick={handleRighButton}>작가 프로필</ModalButton>
-      </div>
-    </ModalInner>
+      <ModalInner {...rest}>
+        <ModalHeader>
+          <span>{title}</span>
+          <Image
+            src="/svg/icons/icon_grayClose.svg"
+            alt="close"
+            width={20}
+            height={20}
+            onClick={onCloseModal}
+            className="cursor-pointer"
+          />
+        </ModalHeader>
+        <MajorDiv>{major}</MajorDiv>
+        <DescriptionDiv>{description}</DescriptionDiv>
+        <div className="flex w-full justify-evenly pt-4">
+          <ModalButton onClick={handleLeftButton}>작품 더보기</ModalButton>
+          <ModalButton onClick={handleRighButton}>작가 프로필</ModalButton>
+        </div>
+      </ModalInner>
+    </>
   );
 }

--- a/src/components/exhibition/Modal.tsx
+++ b/src/components/exhibition/Modal.tsx
@@ -23,7 +23,7 @@ absolute w-full bottom-0 h-auto m-auto rounded-[8px] backdrop-blur-[25.5px] p-5 
   p,
 ) =>
   p.$open
-    ? 'bg-gradient-to-r from-[#FFFFFF]/[.16] to-[#FFFFFF]/[.46] translate-y-[calc(-30vh)]'
+    ? 'bg-gradient-to-r from-[#FFFFFF]/[.16] to-[#FFFFFF]/[.46] translate-y-[-320px]'
     : 'bg-gradient-to-b from-[#FFFFFF]/[.16] to-[#FFFFFF]/[.46] translate-y-[120px]'}
 `;
 const ModalHeader = tw.div<DefaultProps>`

--- a/src/pages/exhibition/index.tsx
+++ b/src/pages/exhibition/index.tsx
@@ -1,5 +1,6 @@
 import 'swiper/css';
 
+import Layout from '@components/common/Layout';
 import Navigate from '@components/common/Navigate';
 import Modal from '@components/exhibition/Modal';
 import Image from 'next/image';
@@ -38,7 +39,7 @@ interface DefaultProps {
 }
 
 const ExhibitionLayout = tw.div<DefaultProps>`
-font-Pretendard w-full px-6 pt-[45px] border h-[812px] relative overflow-y-hidden overflow-x-hidden
+relative h-full w-full max-w-[420px] overflow-x-hidden px-[24px]
 `;
 
 const SwiperButtonDiv = tw.div<DefaultProps>`
@@ -89,62 +90,36 @@ export default function Exhibition() {
   };
 
   return (
-    <ExhibitionLayout>
+    <Layout>
       {isExpansion ? (
-        <>
-          <Image
-            alt="exhibition_bg"
-            src="/svg/icons/bg_exhibition.jpg"
-            quality={100}
-            width={400}
-            height={0}
-            sizes="100vh"
-            style={{
-              objectFit: 'contain',
-            }}
-            className="absolute top-[240px] right-[-3px] scale-[1.8]"
-          />
-          <Image
-            alt="canvas"
-            src="/svg/icons/bg_canvas.svg"
-            quality={100}
-            width={400}
-            height={0}
-            sizes="100vh"
-            style={{
-              objectFit: 'contain',
-            }}
-            className="absolute top-[240px] right-[-3px] scale-[1.8]"
-          />
-        </>
+        <Image
+          alt="exhibition_bg"
+          src="/svg/icons/bg_exhibition.jpg"
+          quality={100}
+          width={400}
+          height={0}
+          sizes="100vh"
+          style={{
+            objectFit: 'contain',
+          }}
+          className="absolute top-[240px] right-[-3px] scale-[2.0]"
+        />
       ) : (
-        <>
-          <Image
-            alt="exhibition_bg"
-            src="/svg/icons/bg_exhibition.jpg"
-            quality={100}
-            fill
-            sizes="100vh"
-            style={{
-              objectFit: 'cover',
-            }}
-          />
-          <Image
-            alt="canvas"
-            src="/svg/icons/bg_canvas.svg"
-            quality={100}
-            fill
-            sizes="100vh"
-            style={{
-              objectFit: 'cover',
-            }}
-          />
-        </>
+        <Image
+          alt="exhibition_bg"
+          src="/svg/icons/bg_exhibition.jpg"
+          quality={100}
+          fill
+          sizes="100vh"
+          style={{
+            objectFit: 'cover',
+          }}
+        />
       )}
-      <Navigate isRightButton={false} />
-      <Swiper className="h-full" ref={swiperRef} spaceBetween={50}>
+      <Navigate isRightButton={false} className="absolute top-0 z-50 w-full" />
+      <Swiper className="absolute h-full" ref={swiperRef} spaceBetween={180}>
         {!isExpansion && !isOpen && (
-          <div className="absolute top-[180px] z-50 flex w-[99%] justify-between">
+          <div className="absolute top-[330px] z-10 flex w-full justify-between">
             <SwiperButtonDiv
               onClick={() => swiperRef.current.swiper.slidePrev()}
             >
@@ -170,8 +145,20 @@ export default function Exhibition() {
         {DUMP_ART_LISTS.map((art, idx) => (
           <SwiperSlide key={idx}>
             {isExpansion ? (
-              <div>
-                <div className="relative mt-[80px]">
+              <div className="flex h-full w-full justify-center">
+                <Image
+                  alt="canvas"
+                  src="/svg/icons/bg_canvas.svg"
+                  quality={100}
+                  width={400}
+                  height={0}
+                  sizes="100vh"
+                  style={{
+                    objectFit: 'contain',
+                  }}
+                  className="absolute top-[240px] scale-[2.0]"
+                />
+                <div className="absolute top-[160px] mr-1 w-[95%]">
                   <Image
                     src="/svg/example/exhibition.svg"
                     alt="image"
@@ -180,7 +167,7 @@ export default function Exhibition() {
                     quality={100}
                   />
                 </div>
-                <div className="absolute top-[95px] right-[15px]">
+                <div className="absolute top-[170px] right-[20px]">
                   <Image
                     src="/svg/icons/icon_maximize.svg"
                     alt="image"
@@ -192,8 +179,20 @@ export default function Exhibition() {
                 </div>
               </div>
             ) : (
-              <div>
-                <div className="relative m-auto mr-[44px] mt-[35px] flex h-[348px] w-[240px] justify-center">
+              <div className="flex h-full w-full justify-center">
+                <Image
+                  alt="canvas"
+                  src="/svg/icons/bg_canvas.svg"
+                  quality={100}
+                  width={400}
+                  height={0}
+                  sizes="100vh"
+                  style={{
+                    objectFit: 'contain',
+                  }}
+                  className="absolute top-[140px] scale-[1.6]"
+                />
+                <div className="absolute top-[130px] mr-1 w-[77%]">
                   <Image
                     src="/svg/example/exhibition.svg"
                     alt="image"
@@ -202,7 +201,7 @@ export default function Exhibition() {
                     quality={100}
                   />
                 </div>
-                <div className="absolute top-[45px] right-[55px]">
+                <div className="absolute top-[140px] right-[55px]">
                   <Image
                     src="/svg/icons/icon_maximize.svg"
                     alt="image"
@@ -215,7 +214,7 @@ export default function Exhibition() {
               </div>
             )}
             {modal && (
-              <div>
+              <div className="flex justify-center">
                 <Modal
                   isOpen={isOpen}
                   $open={isOpen}
@@ -232,6 +231,6 @@ export default function Exhibition() {
           </SwiperSlide>
         ))}
       </Swiper>
-    </ExhibitionLayout>
+    </Layout>
   );
 }

--- a/src/pages/exhibition/index.tsx
+++ b/src/pages/exhibition/index.tsx
@@ -7,7 +7,7 @@ import Image from 'next/image';
 import React from 'react';
 import tw from 'tailwind-styled-components';
 import { useRef, useState } from 'react';
-import { Swiper, SwiperSlide, useSwiper } from 'swiper/react';
+import { Swiper, SwiperSlide } from 'swiper/react';
 import { useRouter } from 'next/router';
 
 const DUMP_ART_LISTS = [
@@ -37,10 +37,6 @@ const DUMP_ART_LISTS = [
 interface DefaultProps {
   [key: string]: any;
 }
-
-const ExhibitionLayout = tw.div<DefaultProps>`
-relative h-full w-full max-w-[420px] overflow-x-hidden px-[24px]
-`;
 
 const SwiperButtonDiv = tw.div<DefaultProps>`
 bg-[rgba(153,153,153,0.24)] rounded-[10px] w-8 h-8 flex justify-center cursor-pointer


### PR DESCRIPTION
## 🧑‍💻 PR 내용

캔버스와 배경이 뒤에 고정되어있고, 그림만 swiper로 구현한 디자인을
캔버스도 같이 움직이도록 디자인 수정했습니다.

## 📸 스크린샷


![녹화_2023_01_30_16_19_56_477](https://user-images.githubusercontent.com/79186378/215413543-a591b665-e8b5-4459-bd14-84e670a78267.gif)
