### PR TITLE
[id]에서 새로고침시 router.query.id 값이 NaN으로 요청보내는 오류 해결

### DIFF
--- a/src/apis/artwork/artworkApi.ts
+++ b/src/apis/artwork/artworkApi.ts
@@ -29,8 +29,8 @@ export class ArtworkApi {
     return data;
   }
 
-  async getExhibitionItem(artworkId: number): Promise<ExhibitionArtWork> {
-    const { data } = await instance.get(`/exhibit/art-works/${artworkId}`);
+  async getExhibitionItem(artWorkId: number): Promise<ExhibitionArtWork> {
+    const { data } = await instance.get(`/exhibit/art-works/${artWorkId}`);
     return data;
   }
   async getBid(): Promise<BidArtwork> {

--- a/src/hooks/queries/auction/useGetBiddingHistory.ts
+++ b/src/hooks/queries/auction/useGetBiddingHistory.ts
@@ -1,11 +1,15 @@
 import auctionApi from '@apis/auction/auctionApi';
 import { useQuery } from 'react-query';
 
-const useGetBiddingHistory = (artworkId: number) => {
+const useGetBiddingHistory = (artWorkId: number) => {
   return useQuery<BiddingHistory, Error>(
-    'useGetBiddingHistory',
-    () => auctionApi.getBiddingHistory(artworkId),
-    { retry: false, refetchOnWindowFocus: false, enabled: !!artworkId },
+    ['useGetBiddingHistory', artWorkId],
+    () => auctionApi.getBiddingHistory(artWorkId),
+    {
+      retry: false,
+      refetchOnWindowFocus: false,
+      enabled: !isNaN(artWorkId),
+    },
   );
 };
 

--- a/src/hooks/queries/useGetDetail.ts
+++ b/src/hooks/queries/useGetDetail.ts
@@ -3,12 +3,12 @@ import { useQuery } from 'react-query';
 
 const useGetDetail = (artWorkId: number) => {
   return useQuery<ArtworkDetail, Error>(
-    'useGetDetail',
+    ['useGetDetail', artWorkId],
     () => artworkApi.getDetail(artWorkId),
     {
       retry: false,
       refetchOnWindowFocus: false,
-      enabled: !!artWorkId,
+      enabled: !isNaN(artWorkId),
     },
   );
 };

--- a/src/hooks/queries/useGetExhibition.ts
+++ b/src/hooks/queries/useGetExhibition.ts
@@ -17,10 +17,10 @@ export const useGetExhibitionItemList = (
   genres: string[],
 ) => {
   return useQuery<ExhibitionArtWork[], Error>(
-    'useGetExhibitionItems',
+    ['useGetExhibitionItems', auctionId],
     () => artworkApi.getExhibitionItemList(auctionId),
     {
-      enabled: !!auctionId,
+      enabled: !isNaN(auctionId),
       select: (arts) => {
         if (genres?.length === 0) {
           return arts;
@@ -33,14 +33,14 @@ export const useGetExhibitionItemList = (
   );
 };
 
-export const useGetExhibitionItem = (auctionId: number) => {
+export const useGetExhibitionItem = (artWorkId: number) => {
   return useQuery<ExhibitionArtWork, Error>(
-    'useGetExhibitionItem',
-    () => artworkApi.getExhibitionItem(auctionId),
+    ['useGetExhibitionItem', artWorkId],
+    () => artworkApi.getExhibitionItem(artWorkId),
     {
       retry: false,
       refetchOnWindowFocus: false,
-      enabled: !!auctionId,
+      enabled: !isNaN(artWorkId),
     },
   );
 };

--- a/src/hooks/queries/useGetPickDetail.ts
+++ b/src/hooks/queries/useGetPickDetail.ts
@@ -3,13 +3,13 @@ import profileApi from '@apis/profile/profileApi';
 
 const useGetPickDetail = (artistId: number) => {
   return useQuery<artistDetail, Error>(
-    'useGetPickDetail',
+    ['useGetPickDetail', artistId],
     () => profileApi.getPickDetail(artistId),
 
     {
       retry: 0,
       refetchOnWindowFocus: false,
-      enabled: !!artistId,
+      enabled: !isNaN(artistId),
     },
   );
 };

--- a/src/pages/auction/[id].tsx
+++ b/src/pages/auction/[id].tsx
@@ -12,8 +12,8 @@ import { useCountDown } from '@hooks/useCountDown';
 export default function Detail() {
   const router = useRouter();
 
-  const artWorkId = router.query.id;
-  const { data: detailData } = useGetDetail(+artWorkId!);
+  const artWorkId = Number(router.query.id);
+  const { data: detailData } = useGetDetail(artWorkId);
   const { artWork, artist } = detailData || {};
   const { mutate: postPrefer } = usePostPrefer(artWork?.id!);
   const { mutate: deletePrefer } = useDeletePrefer(artWork?.id!);

--- a/src/pages/auction/bidding/[id].tsx
+++ b/src/pages/auction/bidding/[id].tsx
@@ -20,8 +20,8 @@ interface inputForm {
 
 export default function Bidding() {
   const router = useRouter();
-  const artWorkId = router.query.id;
-  const { data } = useGetBiddingHistory(+artWorkId!);
+  const artWorkId = Number(router.query.id);
+  const { data } = useGetBiddingHistory(artWorkId);
   const { artWork, auction, biddingList, totalBiddingCount } = data || {};
   const { mutate } = usePutBiddng(+artWorkId!);
   const [days, hours, minutes, seconds] = useCountDown?.(

--- a/src/pages/exhibition/[id].tsx
+++ b/src/pages/exhibition/[id].tsx
@@ -16,7 +16,7 @@ export default function ExhibitionArt() {
   const [isExpansion, setExpansion] = useState<boolean>(false);
 
   const router = useRouter();
-  const id = parseInt(router.query.id as string, 10)!;
+  const id = Number(router.query.id);
 
   const { data: art } = useGetExhibitionItem(id);
 

--- a/src/pages/exhibition/view.tsx
+++ b/src/pages/exhibition/view.tsx
@@ -6,18 +6,13 @@ import GenreModal from '@components/exhibition/GenreModal';
 import Modal from '@components/exhibition/Modal';
 import Image from 'next/image';
 import React from 'react';
-import styled from 'styled-components';
 import tw from 'tailwind-styled-components';
 import { useRef, useState } from 'react';
 import { Swiper, SwiperSlide } from 'swiper/react';
 import { useRouter } from 'next/router';
 import { useGetExhibitionItemList } from '@hooks/queries/useGetExhibition';
 
-interface DefaultProps {
-  [key: string]: any;
-}
-
-const SwiperButtonDiv = tw.div<DefaultProps>`
+const SwiperButtonDiv = tw.div<defaultProps>`
 bg-[rgba(153,153,153,0.24)] rounded-[10px] w-8 h-8 flex justify-center cursor-pointer
 `;
 
@@ -31,7 +26,7 @@ export default function ExhibitionArts() {
   const swiperRef = useRef<any>(null);
 
   const router = useRouter();
-  const id = parseInt(router.query.id as string, 10)!;
+  const id = Number(router.query.id);
 
   const { data: artLists } = useGetExhibitionItemList(id, genre);
 
@@ -66,10 +61,6 @@ export default function ExhibitionArts() {
       />
     );
 
-  if (!artLists?.length) {
-    alert('등록된 작품이 없습니다.');
-    router.replace('/home');
-  }
   return (
     <Layout>
       {isExpansion ? (

--- a/src/pages/profile/[id].tsx
+++ b/src/pages/profile/[id].tsx
@@ -24,7 +24,7 @@ w-[60px] mr-[10px] aspect-square flex  justify-center items-center rounded-full 
 
 export default function PickDetail() {
   const router = useRouter();
-  const artistId = parseInt(router.query.id as string, 10)!;
+  const artistId = Number(router.query.id);
 
   const { data: pickDetail } = useGetPickDetail(artistId);
   const { member, artworks, pick } = pickDetail || {};


### PR DESCRIPTION
## 🧑‍💻 PR 내용
[id]로 dynamic routing을 하는 페이지에서 새로고침을 하면 router.query.id 값을 읽기전 NaN으로 api 요청을 보내는 오류가 있었습니다. 

1. router.query.id를 Number로 type casting
2. ! 연산자 제거
3. quereykey에 id추가 및 enabled를 !isNaN(id)로 설정
 
하여 오류를 해결했습니다. 

경매, 픽작가, 전시회 페이지에서 동일하게 처리했습니다.  
## 📸 스크린샷

<img width="332" alt="image" src="https://user-images.githubusercontent.com/92621861/217133421-43789962-d294-4a9f-a17a-ec8927e9a473.png">