### PR TITLE
검색 페이지 기능 구현

### DIFF
--- a/public/svg/icons/icon_checked_brand.svg
+++ b/public/svg/icons/icon_checked_brand.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M5.58333 9L12.2917 16L19 9" stroke="#FC6554" stroke-width="1.91467" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/@types/search.d.ts
+++ b/src/@types/search.d.ts
@@ -1,0 +1,15 @@
+interface RecentSearch {
+  id: number;
+  word: string;
+}
+
+interface SearchArtWork {
+  id: number;
+  image: string;
+  title: string;
+  artistName: string;
+  education: string;
+  pick: boolean;
+  status: string;
+  artistId: number;
+}

--- a/src/apis/artwork/artworkApi.ts
+++ b/src/apis/artwork/artworkApi.ts
@@ -42,6 +42,24 @@ export class ArtworkApi {
     const { data } = await instance.get('/art-works/me');
     return data;
   }
+
+  async getRecentSearch(): Promise<RecentSearch[]> {
+    const { data } = await instance.get('/search');
+    return data;
+  }
+
+  async getSearchArtwork(word: string): Promise<SearchArtWork[]> {
+    const { data } = await instance.get(`/search/art-works/${word}`);
+    return data;
+  }
+
+  async deleteRecentWord(wordId: number) {
+    await instance.delete(`/search/${wordId}`);
+  }
+
+  async deleteRecentAllWords() {
+    await instance.delete(`/search`);
+  }
 }
 
 const artworkApi = new ArtworkApi();

--- a/src/components/search/FilterDropdown.tsx
+++ b/src/components/search/FilterDropdown.tsx
@@ -1,0 +1,106 @@
+import { Menu, Transition } from '@headlessui/react';
+import { Fragment, useState, Dispatch, SetStateAction } from 'react';
+import Image from 'next/image';
+
+interface FilterDropdownProps {
+  setStatus: Dispatch<SetStateAction<string[]>>;
+}
+
+export default function FilterDropdown({ setStatus }: FilterDropdownProps) {
+  const [selected, setSelected] = useState<string[]>([]);
+
+  return (
+    <div>
+      <Menu as="div" className="relative">
+        <div className="w-full">
+          <Menu.Button className="m-auto ml-0 flex w-[80px] items-center  justify-around rounded-[19px] border-[1px] border-[#DBDBDB] bg-white px-3 py-2 text-sm font-medium text-[#767676]">
+            정렬
+            <Image
+              src="/svg/icons/icon_arrow_down.svg"
+              alt="checked"
+              width={12}
+              height={10}
+            />
+          </Menu.Button>
+        </div>
+        <Transition
+          as={Fragment}
+          enter="transition ease-out duration-100"
+          enterFrom="transform opacity-0 scale-95"
+          enterTo="transform opacity-100 scale-100"
+          leave="transition ease-in duration-75"
+          leaveFrom="transform opacity-100 scale-100"
+          leaveTo="transform opacity-0 scale-95"
+        >
+          <Menu.Items className="absolute z-50 mt-2 w-full divide-gray-100 rounded-md bg-white shadow-lg ring-1 ring-black ring-opacity-5">
+            <div className="px-1 py-1 ">
+              <Menu.Item>
+                <button
+                  className="flex w-full items-center justify-between border-b-[1px] py-3 px-2 text-sm"
+                  onClick={() => {
+                    setStatus(() => []);
+                    setSelected(() => []);
+                  }}
+                >
+                  모두
+                  {selected.length === 0 ? (
+                    <Image
+                      src="/svg/icons/icon_checked_brand.svg"
+                      alt="checked"
+                      width={20}
+                      height={20}
+                    />
+                  ) : (
+                    <></>
+                  )}
+                </button>
+              </Menu.Item>
+              <Menu.Item>
+                <button
+                  className="flex w-full items-center justify-between border-b-[1px] py-3 px-2 text-sm"
+                  onClick={() => {
+                    setStatus(() => ['processing']);
+                    setSelected(() => ['processing']);
+                  }}
+                >
+                  경매중
+                  {selected.includes('processing') ? (
+                    <Image
+                      src="/svg/icons/icon_checked_brand.svg"
+                      alt="checked"
+                      width={20}
+                      height={20}
+                    />
+                  ) : (
+                    <></>
+                  )}
+                </button>
+              </Menu.Item>
+              <Menu.Item>
+                <button
+                  className="flex w-full items-center justify-between py-3 px-2 text-sm"
+                  onClick={() => {
+                    setStatus(() => ['sales_success']);
+                    setSelected(() => ['sales_success']);
+                  }}
+                >
+                  경매완료
+                  {selected.includes('sales_success') ? (
+                    <Image
+                      src="/svg/icons/icon_checked_brand.svg"
+                      alt="checked"
+                      width={20}
+                      height={20}
+                    />
+                  ) : (
+                    <></>
+                  )}
+                </button>
+              </Menu.Item>
+            </div>
+          </Menu.Items>
+        </Transition>
+      </Menu>
+    </div>
+  );
+}

--- a/src/components/search/FilterDropdown.tsx
+++ b/src/components/search/FilterDropdown.tsx
@@ -10,8 +10,8 @@ export default function FilterDropdown({ setStatus }: FilterDropdownProps) {
   const [selected, setSelected] = useState<string[]>([]);
 
   const handleMenu = (status: string) => {
-    setStatus(() => [status]);
-    setSelected(() => [status]);
+    setStatus([status]);
+    setSelected([status]);
   };
   return (
     <div>
@@ -42,8 +42,8 @@ export default function FilterDropdown({ setStatus }: FilterDropdownProps) {
                 <button
                   className="flex w-full items-center justify-between border-b-[1px] py-3 px-2 text-sm"
                   onClick={() => {
-                    setStatus(() => []);
-                    setSelected(() => []);
+                    setStatus([]);
+                    setSelected([]);
                   }}
                 >
                   모두

--- a/src/components/search/FilterDropdown.tsx
+++ b/src/components/search/FilterDropdown.tsx
@@ -9,6 +9,10 @@ interface FilterDropdownProps {
 export default function FilterDropdown({ setStatus }: FilterDropdownProps) {
   const [selected, setSelected] = useState<string[]>([]);
 
+  const handleMenu = (status: string) => {
+    setStatus(() => [status]);
+    setSelected(() => [status]);
+  };
   return (
     <div>
       <Menu as="div" className="relative">
@@ -58,10 +62,7 @@ export default function FilterDropdown({ setStatus }: FilterDropdownProps) {
               <Menu.Item>
                 <button
                   className="flex w-full items-center justify-between border-b-[1px] py-3 px-2 text-sm"
-                  onClick={() => {
-                    setStatus(() => ['processing']);
-                    setSelected(() => ['processing']);
-                  }}
+                  onClick={() => handleMenu('processing')}
                 >
                   경매중
                   {selected.includes('processing') ? (
@@ -79,10 +80,7 @@ export default function FilterDropdown({ setStatus }: FilterDropdownProps) {
               <Menu.Item>
                 <button
                   className="flex w-full items-center justify-between py-3 px-2 text-sm"
-                  onClick={() => {
-                    setStatus(() => ['sales_success']);
-                    setSelected(() => ['sales_success']);
-                  }}
+                  onClick={() => handleMenu('sales_success')}
                 >
                   경매완료
                   {selected.includes('sales_success') ? (

--- a/src/components/search/RecentSearchBox.tsx
+++ b/src/components/search/RecentSearchBox.tsx
@@ -1,0 +1,41 @@
+import tw from 'tailwind-styled-components';
+import Image from 'next/image';
+import { useDeleteWord } from '@hooks/mutations/useDeleteWord';
+
+interface RecentSearchProps {
+  data: RecentSearch;
+  handleRecentWord(word: string): void;
+  [key: string]: any;
+}
+
+interface DefaultProps {
+  [key: string]: any;
+}
+
+const RecentKeywordBox = tw.li<DefaultProps>`
+border-b-[1px] border-[#EDEDED] text-[#767676] flex px-2 justify-between basis-[48.6%] p-0 cursor-pointer odd:mr-2 pb-1 mt-2
+`;
+
+export default function RecentSearchBox({
+  data,
+  handleRecentWord,
+}: RecentSearchProps) {
+  const { mutate: deleteWord } = useDeleteWord(data?.id);
+  const handleDelete = () => {
+    deleteWord();
+  };
+  return (
+    <RecentKeywordBox>
+      <span onClick={() => handleRecentWord(data.word)}>{data.word}</span>
+      <span className="ml-2 flex align-middle">
+        <Image
+          src="/svg/icons/icon_grayClose.svg"
+          alt="close"
+          width={20}
+          height={20}
+          onClick={handleDelete}
+        />
+      </span>
+    </RecentKeywordBox>
+  );
+}

--- a/src/components/search/SearchItem.tsx
+++ b/src/components/search/SearchItem.tsx
@@ -1,0 +1,59 @@
+import useDeletePrefer from '@hooks/mutations/useDeletePrefer';
+import usePostPrefer from '@hooks/mutations/usePostPrefer';
+import Image from 'next/image';
+import { useRouter } from 'next/router';
+
+interface ArtworkForm {
+  artwork: SearchArtWork;
+}
+
+export default function SearchItem({ artwork }: ArtworkForm) {
+  const router = useRouter();
+  const { mutate: deletePrefer } = useDeletePrefer(artwork.id);
+  const { mutate: postPrefer } = usePostPrefer(artwork.id);
+  const handlePrefer = (artworkPick) => {
+    if (artworkPick) {
+      deletePrefer();
+    } else {
+      postPrefer();
+    }
+  };
+  return (
+    <div className="relative h-[197px] w-[158px] rounded">
+      <Image
+        src={artwork.image}
+        alt="notification"
+        fill
+        sizes="1000"
+        style={{
+          objectFit: 'cover',
+        }}
+        priority
+        className="rounded"
+        quality={100}
+        onClick={() => {
+          router.push(`/exhibition/${artwork.id}`);
+        }}
+      />
+
+      <div className="h-full w-full rounded bg-gradient-to-b from-[rgba(0,0,0,0)] via-[rgba(0,0,0,0)] to-[rgba(0,0,0,0.5)]">
+        <div className="absolute bottom-3 left-2 flex flex-col text-[#FFFFFF]">
+          <div className="text-14 font-bold">{artwork.title}</div>
+          <div className="flex items-center text-12">
+            {artwork.artistName}
+            <div className="mx-1 h-[10px] w-[1px] bg-white"></div>
+            {artwork.education}
+          </div>
+        </div>
+      </div>
+      <Image
+        src={`/svg/icons/icon_heart${artwork.pick ? '_filled' : ''}.svg`}
+        alt="heart"
+        width={20}
+        height={20}
+        className="absolute right-2 top-2.5"
+        onClick={() => handlePrefer(artwork.pick)}
+      />
+    </div>
+  );
+}

--- a/src/hooks/mutations/useDeleteWord.ts
+++ b/src/hooks/mutations/useDeleteWord.ts
@@ -9,7 +9,6 @@ export const useDeleteWord = (wordId: number) => {
     {
       onMutate: async () => {
         await queryClient.cancelQueries({ queryKey: ['useDeleteWord'] });
-        console.log(wordId);
         const previousValue = queryClient.getQueryData(['useGetRecentSearch']);
         queryClient.setQueryData(['useGetRecentSearch'], (old: any) =>
           old.filter((t) => t.id !== wordId),

--- a/src/hooks/mutations/useDeleteWord.ts
+++ b/src/hooks/mutations/useDeleteWord.ts
@@ -1,0 +1,52 @@
+import artworkApi from '@apis/artwork/artworkApi';
+import { queryClient } from 'pages/_app';
+import { useMutation } from 'react-query';
+
+export const useDeleteWord = (wordId: number) => {
+  return useMutation<any, Error>(
+    'useDeleteWord',
+    () => artworkApi.deleteRecentWord(wordId),
+    {
+      onMutate: async () => {
+        await queryClient.cancelQueries({ queryKey: ['useDeleteWord'] });
+        console.log(wordId);
+        const previousValue = queryClient.getQueryData(['useGetRecentSearch']);
+        queryClient.setQueryData(['useGetRecentSearch'], (old: any) =>
+          old.filter((t) => t.id !== wordId),
+        );
+        return { previousValue };
+      },
+      onError: (context: any) => {
+        queryClient.setQueryData(['useGetRecentSearch'], context.previousValue);
+      },
+      onSettled: () => {
+        queryClient.invalidateQueries({
+          queryKey: ['useGetRecentSearch'],
+        });
+      },
+    },
+  );
+};
+
+export const useDeleteAllWord = () => {
+  return useMutation<any, Error>(
+    'useDeleteAllWord',
+    () => artworkApi.deleteRecentAllWords(),
+    {
+      onMutate: async () => {
+        await queryClient.cancelQueries({ queryKey: ['useDeleteAllWord'] });
+        const previousValue = queryClient.getQueryData(['useGetRecentSearch']);
+        queryClient.setQueryData(['useGetRecentSearch'], () => []);
+        return { previousValue };
+      },
+      onError: (context: any) => {
+        queryClient.setQueryData(['useGetRecentSearch'], context.previousValue);
+      },
+      onSettled: () => {
+        queryClient.invalidateQueries({
+          queryKey: ['useGetRecentSearch'],
+        });
+      },
+    },
+  );
+};

--- a/src/hooks/queries/useGetSearchArtWork.ts
+++ b/src/hooks/queries/useGetSearchArtWork.ts
@@ -1,0 +1,26 @@
+import artworkApi from '@apis/artwork/artworkApi';
+import { useQuery } from 'react-query';
+
+export const useGetRecentSearch = () => {
+  return useQuery<RecentSearch[], Error>('useGetRecentSearch', () =>
+    artworkApi.getRecentSearch(),
+  );
+};
+
+export const useGetSearch = (word: string, status: string[]) => {
+  return useQuery<SearchArtWork[], Error>(
+    ['useGetSearch', word],
+    () => artworkApi.getSearchArtwork(word),
+    {
+      enabled: !!word,
+      select: (arts) => {
+        if (status?.length === 0) {
+          return arts;
+        } else {
+          const selected = arts.filter((art) => status.includes(art.status));
+          return selected;
+        }
+      },
+    },
+  );
+};


### PR DESCRIPTION
## 🧑‍💻 PR 내용

검색 페이지에서 사용하는 검색 작품 컴포넌트, 정렬 드롭다운 컴포넌트, 최근 검색어 컴포넌트를 생성했습니다.
검색 페이지에서 사용되는 타입들을 search.d.ts 내부에 지정했습니다.

검색페이지 내부에서는 최근 검색어와, 키워드를 클릭하면 해당 검색어와 키워드로 검색하도록 구현했습니다.
낙관적 업데이트를 통해 최근검색어 삭제 뮤테이션을 구현했습니다.
드롭다운에서 state를 활용하여 해당 state를 useQuery에 넘겨 state에 따라 검색 작품 필터링을 구현했습니다.

## 📸 스크린샷


![녹화_2023_02_07_14_34_51_573](https://user-images.githubusercontent.com/79186378/217159141-52978379-874a-40d8-82a2-86ca48f11f14.gif)
