### PR TITLE
작품 찜하기 - 낙관적 업데이트(home, view, auction/id 페이지)

### DIFF
--- a/src/@types/index.d.ts
+++ b/src/@types/index.d.ts
@@ -16,7 +16,6 @@ interface KeywordArtwork {
   title: string;
   education: string;
   pick: boolean;
-  refetchCustomizedArtwork: () => void;
 }
 
 interface CustomizeArtwork {

--- a/src/components/home/ExhibitionItem.tsx
+++ b/src/components/home/ExhibitionItem.tsx
@@ -11,8 +11,9 @@ export default function ExhibitionItem({
   pick,
 }: KeywordArtwork) {
   const router = useRouter();
-  const { mutate: deletePrefer } = useDeletePrefer(+id, 'home');
-  const { mutate: postPrefer } = usePostPrefer(+id, 'home');
+
+  const { mutate: deletePrefer } = useDeletePrefer(+id, router.asPath);
+  const { mutate: postPrefer } = usePostPrefer(+id, router.asPath);
   const handlePrefer = (e) => {
     e.stopPropagation();
     if (pick) {

--- a/src/components/home/ExhibitionItem.tsx
+++ b/src/components/home/ExhibitionItem.tsx
@@ -9,19 +9,16 @@ export default function ExhibitionItem({
   title,
   id,
   pick,
-  refetchCustomizedArtwork,
 }: KeywordArtwork) {
   const router = useRouter();
-  const { mutate: deletePrefer } = useDeletePrefer(+id);
-  const { mutate: postPrefer } = usePostPrefer(+id);
-  const handlePrefer = async (e) => {
+  const { mutate: deletePrefer } = useDeletePrefer(+id, 'home');
+  const { mutate: postPrefer } = usePostPrefer(+id, 'home');
+  const handlePrefer = (e) => {
     e.stopPropagation();
     if (pick) {
-      await deletePrefer();
-      await refetchCustomizedArtwork();
+      deletePrefer();
     } else {
-      await postPrefer();
-      await refetchCustomizedArtwork();
+      postPrefer();
     }
   };
   return (

--- a/src/components/notice/NoticeItem.tsx
+++ b/src/components/notice/NoticeItem.tsx
@@ -58,13 +58,13 @@ export default function NoticeItem({ notice, refetchNotice }: NoticeItemProps) {
         src={`/svg/icons/notice/icon_notice_${
           icon[title] && icon[title][0]
         }.svg`}
-        width="40"
-        height="0"
-        className="ml-2 mr-4"
+        width={37}
+        height={37}
+        className="ml-1 mr-3"
       />
       <section className="flex flex-col leading-5">
         <p className="text-[12px] font-bold">{title}</p>
-        <p className="flex w-[240px] justify-between text-[14px]">
+        <p className="flex w-[260px] justify-between text-[14px]">
           {notice.message}
         </p>
         <p className="text-[10px] text-[#999999]">{modifiedDate}</p>

--- a/src/components/notice/NoticeItem.tsx
+++ b/src/components/notice/NoticeItem.tsx
@@ -23,12 +23,13 @@ export default function NoticeItem({ notice, refetchNotice }: NoticeItemProps) {
     .replace('ago', '전');
   let title: string = notice.title;
   if (
-    notice?.title === '작품 등록 완료' ||
-    '작가 등록 완료' ||
-    '작품 낙찰 성공'
+    ['작품 등록 완료', '작가 등록 완료', '작품 낙찰 성공'].includes(
+      notice?.title,
+    )
   ) {
     title += ' 🎉';
   }
+  console.log(notice?.title);
 
   const icon = {
     '작가 등록 완료 🎉': ['post', '/profile/edit'],

--- a/src/components/profile/WishCard.tsx
+++ b/src/components/profile/WishCard.tsx
@@ -13,7 +13,7 @@ rounded-lg hover:ring-1 hover:ring-blue-500 cursor-pointer relative
 
 export default function WishCard({ wish }) {
   const router = useRouter();
-  const { mutate: deletePrefer } = useDeletePrefer(wish?.id);
+  const { mutate: deletePrefer } = useDeletePrefer(wish?.id, '/wish');
   const handlePrefer = (e) => {
     e.stopPropagation();
     deletePrefer();

--- a/src/components/search/SearchItem.tsx
+++ b/src/components/search/SearchItem.tsx
@@ -9,8 +9,8 @@ interface ArtworkForm {
 
 export default function SearchItem({ artwork }: ArtworkForm) {
   const router = useRouter();
-  const { mutate: deletePrefer } = useDeletePrefer(artwork.id);
-  const { mutate: postPrefer } = usePostPrefer(artwork.id);
+  const { mutate: deletePrefer } = useDeletePrefer(artwork.id, router.asPath);
+  const { mutate: postPrefer } = usePostPrefer(artwork.id, router.asPath);
   const handlePrefer = (artworkPick) => {
     if (artworkPick) {
       deletePrefer();

--- a/src/hooks/mutations/useDeletePrefer.ts
+++ b/src/hooks/mutations/useDeletePrefer.ts
@@ -50,6 +50,12 @@ const Querykey = {
     convertFunc: (old, artWorkId: number) =>
       old.filter((it) => it.id !== artWorkId),
   },
+  '/search': {
+    getDataQuery: 'useGetSearch',
+    convertFunc: (old, artWorkId: number) => {
+      console.log(old, artWorkId);
+    },
+  },
 };
 
 const useDeletePrefer = (artWorkId: number, path: string) => {
@@ -63,9 +69,9 @@ const useDeletePrefer = (artWorkId: number, path: string) => {
         const previousValue = queryClient.getQueryData([
           Querykey[path].getDataQuery,
         ]);
-        queryClient.setQueryData([Querykey[path].getDataQuery], (old: any) => {
-          return Querykey[path].convertFunc(old);
-        });
+        queryClient.setQueryData([Querykey[path].getDataQuery], (old: any) =>
+          Querykey[path].convertFunc(old),
+        );
         return { previousValue };
       },
       onError: (context: any) => {

--- a/src/hooks/mutations/useDeletePrefer.ts
+++ b/src/hooks/mutations/useDeletePrefer.ts
@@ -45,6 +45,11 @@ const Querykey = {
       };
     },
   },
+  '/wish': {
+    getDataQuery: 'useGetWish',
+    convertFunc: (old, artWorkId: number) =>
+      old.filter((it) => it.id !== artWorkId),
+  },
 };
 
 const useDeletePrefer = (artWorkId: number, path: string) => {

--- a/src/hooks/mutations/useDeletePrefer.ts
+++ b/src/hooks/mutations/useDeletePrefer.ts
@@ -11,7 +11,7 @@ const Querykey = {
   },
   '/home': {
     getDataQuery: 'useCustomizedArtWork',
-    convertFunc: (old, artWorkId) => {
+    convertFunc: (old, artWorkId: number) => {
       return {
         ...old,
         artworks: old.artworks.map((it) => {
@@ -26,7 +26,7 @@ const Querykey = {
   },
   '/home/view': {
     getDataQuery: 'useInfiniteArtWork',
-    convertFunc: (old, artWorkId) => {
+    convertFunc: (old, artWorkId: number) => {
       console.log(old);
       return {
         ...old,
@@ -47,7 +47,7 @@ const Querykey = {
   },
 };
 
-const useDeletePrefer = (artWorkId: number, path) => {
+const useDeletePrefer = (artWorkId: number, path: string) => {
   return useMutation<any, Error>(
     'useDeletePrefer',
     () => artworkApi.deletePrefer(artWorkId),

--- a/src/hooks/mutations/useDeletePrefer.ts
+++ b/src/hooks/mutations/useDeletePrefer.ts
@@ -1,10 +1,15 @@
 import artworkApi from '@apis/artwork/artworkApi';
-import profileApi from '@apis/profile/profileApi';
 import { queryClient } from 'pages/_app';
 import { useMutation } from 'react-query';
 
 const Querykey = {
-  home: {
+  '/auction': {
+    getDataQuery: 'useGetDetail',
+    convertFunc: (old) => {
+      return { ...old, pick: false };
+    },
+  },
+  '/home': {
     getDataQuery: 'useCustomizedArtWork',
     convertFunc: (old, artWorkId) => {
       return {
@@ -19,10 +24,25 @@ const Querykey = {
       };
     },
   },
-  auction: {
-    getDataQuery: 'useGetDetail',
-    convertFunc: (old) => {
-      return { ...old, pick: false };
+  '/home/view': {
+    getDataQuery: 'useInfiniteArtWork',
+    convertFunc: (old, artWorkId) => {
+      console.log(old);
+      return {
+        ...old,
+        pages: old.pages.map((page) => {
+          return {
+            ...page,
+            artworks: page.artworks.map((artwork) => {
+              if (artwork.id === artWorkId) {
+                return { ...artwork, pick: false };
+              } else {
+                return artwork;
+              }
+            }),
+          };
+        }),
+      };
     },
   },
 };

--- a/src/hooks/mutations/usePostPrefer.ts
+++ b/src/hooks/mutations/usePostPrefer.ts
@@ -11,7 +11,7 @@ const Querykey = {
   },
   '/home': {
     getDataQuery: 'useCustomizedArtWork',
-    convertFunc: (old, artWorkId) => {
+    convertFunc: (old, artWorkId: number) => {
       return {
         ...old,
         artworks: old.artworks.map((it) => {
@@ -26,7 +26,7 @@ const Querykey = {
   },
   '/home/view': {
     getDataQuery: 'useInfiniteArtWork',
-    convertFunc: (old, artWorkId) => {
+    convertFunc: (old, artWorkId: number) => {
       console.log(old);
       return {
         ...old,

--- a/src/hooks/mutations/usePostPrefer.ts
+++ b/src/hooks/mutations/usePostPrefer.ts
@@ -1,10 +1,15 @@
 import artworkApi from '@apis/artwork/artworkApi';
-import profileApi from '@apis/profile/profileApi';
 import { queryClient } from 'pages/_app';
 import { useMutation } from 'react-query';
 
 const Querykey = {
-  home: {
+  '/auction': {
+    getDataQuery: 'useGetDetail',
+    convertFunc: (old) => {
+      return { ...old, pick: true };
+    },
+  },
+  '/home': {
     getDataQuery: 'useCustomizedArtWork',
     convertFunc: (old, artWorkId) => {
       return {
@@ -19,15 +24,30 @@ const Querykey = {
       };
     },
   },
-  auction: {
-    getDataQuery: 'useGetDetail',
-    convertFunc: (old) => {
-      return { ...old, pick: true };
+  '/home/view': {
+    getDataQuery: 'useInfiniteArtWork',
+    convertFunc: (old, artWorkId) => {
+      console.log(old);
+      return {
+        ...old,
+        pages: old.pages.map((page) => {
+          return {
+            ...page,
+            artworks: page.artworks.map((artwork) => {
+              if (artwork.id === artWorkId) {
+                return { ...artwork, pick: true };
+              } else {
+                return artwork;
+              }
+            }),
+          };
+        }),
+      };
     },
   },
 };
 
-const usePostPrefer = (artWorkId: number, path) => {
+const usePostPrefer = (artWorkId: number, path: string) => {
   return useMutation<any, Error>(
     'usePostPrefer',
     () => artworkApi.postPrefer(artWorkId),

--- a/src/hooks/mutations/usePostPrefer.ts
+++ b/src/hooks/mutations/usePostPrefer.ts
@@ -27,7 +27,6 @@ const Querykey = {
   '/home/view': {
     getDataQuery: 'useInfiniteArtWork',
     convertFunc: (old, artWorkId: number) => {
-      console.log(old);
       return {
         ...old,
         pages: old.pages.map((page) => {
@@ -43,6 +42,12 @@ const Querykey = {
           };
         }),
       };
+    },
+  },
+  '/search': {
+    getDataQuery: 'useGetSearch',
+    convertFunc: (old, artWorkId: number) => {
+      console.log(old, artWorkId);
     },
   },
 };

--- a/src/hooks/queries/useGetDuplicateCheck.ts
+++ b/src/hooks/queries/useGetDuplicateCheck.ts
@@ -24,6 +24,7 @@ const useGetDuplicateCheck = ({ userId, email, nickname }: DuplicateCheck) => {
       ...query,
       retry: false,
       refetchOnWindowFocus: false,
+      suspense: false,
     })),
   );
 };

--- a/src/pages/auction/[id].tsx
+++ b/src/pages/auction/[id].tsx
@@ -222,17 +222,17 @@ export default function Detail() {
           <div className="mt-8 border-y border-y-[#EDEDED] py-8">
             <div className="flex w-[74px] flex-col items-center justify-center">
               <p className="w-full text-center font-medium">작가프로필</p>
-              <div className="my-2 flex aspect-square w-[4rem] items-center justify-center rounded-full border border-[#999999]">
+              <div className="relative my-2 flex aspect-square w-[4rem] items-center justify-center rounded-full border border-[#999999]">
                 <Image
                   src={
                     artist?.artistImage || '/svg/icons/profile/icon_avatar.svg'
                   }
-                  width="35"
-                  height="0"
                   alt="profile"
                   onClick={() => {
                     router.push(`/profile/${artist?.id}`);
                   }}
+                  fill
+                  className="rounded-full"
                 />
               </div>
               <div className="w-fulltext-center ">{artist?.artistName}</div>

--- a/src/pages/auction/[id].tsx
+++ b/src/pages/auction/[id].tsx
@@ -17,8 +17,8 @@ export default function Detail() {
   const { data: detailData } = useGetDetail(artWorkId);
   const { artWork, artist } = detailData || {};
   const { data: userInfo } = useGetProfile();
-  const { mutate: postPrefer } = usePostPrefer(artWork?.id!);
-  const { mutate: deletePrefer } = useDeletePrefer(artWork?.id!);
+  const { mutate: postPrefer } = usePostPrefer(artWork?.id!, 'auction');
+  const { mutate: deletePrefer } = useDeletePrefer(artWork?.id!, 'auction');
   const [days, hours, minutes, seconds] = useCountDown?.(
     detailData?.endDate || '',
   );

--- a/src/pages/auction/[id].tsx
+++ b/src/pages/auction/[id].tsx
@@ -17,8 +17,8 @@ export default function Detail() {
   const { data: detailData } = useGetDetail(artWorkId);
   const { artWork, artist } = detailData || {};
   const { data: userInfo } = useGetProfile();
-  const { mutate: postPrefer } = usePostPrefer(artWork?.id!, 'auction');
-  const { mutate: deletePrefer } = useDeletePrefer(artWork?.id!, 'auction');
+  const { mutate: postPrefer } = usePostPrefer(artWork?.id!, '/auction');
+  const { mutate: deletePrefer } = useDeletePrefer(artWork?.id!, '/auction');
   const [days, hours, minutes, seconds] = useCountDown?.(
     detailData?.endDate || '',
   );

--- a/src/pages/home/index.tsx
+++ b/src/pages/home/index.tsx
@@ -111,7 +111,6 @@ export default function Home() {
                     title={art.title}
                     id={art.id}
                     pick={art.pick}
-                    refetchCustomizedArtwork={refetchCustomizedArtwork}
                   />
                 </SwiperSlide>
               ),

--- a/src/pages/home/view.tsx
+++ b/src/pages/home/view.tsx
@@ -16,12 +16,7 @@ export default function View() {
   const [isLoaded, setIsLoaded] = useState<boolean>(false);
 
   const { data: userInfo } = useGetProfile();
-  const {
-    data,
-    hasNextPage,
-    fetchNextPage,
-    refetch: refetchCustomizedArtwork,
-  } = useGetInfiniteArtWork();
+  const { data, hasNextPage, fetchNextPage } = useGetInfiniteArtWork();
 
   const artworkLists = useMemo(
     () => data?.pages.flatMap((page) => page.artworks),
@@ -71,15 +66,14 @@ export default function View() {
         <p className="text-[20px] font-bold text-[#191919]">이번 주 전시작품</p>
       </div>
       <div className="mt-6 flex w-full flex-wrap justify-center gap-y-5 gap-x-5">
-        {artworkLists?.map((art, idx: number) => (
+        {artworkLists?.map((art) => (
           <ExhibitionItem
-            key={idx}
+            key={art.id}
             image={art.image}
             education={art.education}
             title={art.title}
             id={art.id}
             pick={art.pick}
-            refetchCustomizedArtwork={refetchCustomizedArtwork}
           />
         ))}
         <div ref={target} className="flex h-[100px] w-full justify-center">

--- a/src/pages/profile/index.tsx
+++ b/src/pages/profile/index.tsx
@@ -114,7 +114,15 @@ export default function Profile() {
           <WelcomeBox>
             <div className="relative flex h-[54px] w-[54px] items-center overflow-hidden rounded-full bg-[#EDEDED]">
               {data?.image ? (
-                <Image src={data?.image} fill alt="profile" priority />
+                <Image
+                  src={data?.image}
+                  alt="profile"
+                  priority
+                  fill
+                  className="object-cover"
+                  // width={100}
+                  // height={100}
+                />
               ) : (
                 <Image
                   src="/svg/icons/icon_user_gray.svg"
@@ -240,3 +248,4 @@ export default function Profile() {
     </>
   );
 }
+//

--- a/src/pages/profile/index.tsx
+++ b/src/pages/profile/index.tsx
@@ -120,8 +120,6 @@ export default function Profile() {
                   priority
                   fill
                   className="object-cover"
-                  // width={100}
-                  // height={100}
                 />
               ) : (
                 <Image

--- a/src/pages/profile/index.tsx
+++ b/src/pages/profile/index.tsx
@@ -112,15 +112,9 @@ export default function Profile() {
         />
         <section>
           <WelcomeBox>
-            <div className="flex h-[54px] w-[54px] items-center overflow-hidden rounded-full bg-[#EDEDED]">
+            <div className="relative flex h-[54px] w-[54px] items-center overflow-hidden rounded-full bg-[#EDEDED]">
               {data?.image ? (
-                <Image
-                  src={data?.image}
-                  width="54"
-                  height="54"
-                  alt="profile"
-                  priority
-                />
+                <Image src={data?.image} fill alt="profile" priority />
               ) : (
                 <Image
                   src="/svg/icons/icon_user_gray.svg"

--- a/src/pages/profile/wish.tsx
+++ b/src/pages/profile/wish.tsx
@@ -2,8 +2,7 @@ import Layout from '@components/common/Layout';
 import Navigate from '@components/common/Navigate';
 import WishCard from '@components/profile/WishCard';
 import tw from 'tailwind-styled-components';
-import React, { useState } from 'react';
-import { useRouter } from 'next/router';
+import React from 'react';
 import useGetWish from '@hooks/queries/profile/useGetWish';
 
 interface defaultProps {
@@ -15,8 +14,7 @@ w-full grid grid-cols-2 gap-x-[15px] gap-y-[23px]
 `;
 
 export default function Wish() {
-  const router = useRouter();
-  const { data: wishList, refetch: refetchWish } = useGetWish() || [];
+  const { data: wishList } = useGetWish() || [];
   return (
     <Layout>
       <Navigate message="찜 목록" isRightButton={false} />

--- a/src/pages/search.tsx
+++ b/src/pages/search.tsx
@@ -14,6 +14,7 @@ import {
 } from '@hooks/queries/useGetSearchArtWork';
 import { useDeleteAllWord } from '@hooks/mutations/useDeleteWord';
 import FilterDropdown from '@components/search/FilterDropdown';
+import KeywordBox from '@components/common/KeywordBox';
 
 interface Genre {
   id: string;
@@ -104,7 +105,7 @@ export default function Search() {
       {searchWord ? (
         <div>
           <FilterDropdown setStatus={setStatus} />
-          <div className="flex flex-wrap justify-between gap-y-2 px-5 py-5">
+          <div className="flex flex-wrap justify-between gap-y-2  px-2 py-5">
             {searchResults?.map((artwork: SearchArtWork, idx) => (
               <SearchItem artwork={artwork} key={+idx} />
             ))}
@@ -117,13 +118,11 @@ export default function Search() {
               <div className="text-base font-semibold ">장르</div>
               <div className="mt-2 flex flex-wrap">
                 {GENRELIST.map((genre) => (
-                  <div
+                  <KeywordBox
                     key={genre.id}
-                    className="my-[6px] mr-3 cursor-pointer  rounded-[19px] border py-1 px-3 text-14 font-bold text-[#767676]"
                     onClick={() => handleRecommendKeyword(genre.name)}
-                  >
-                    {genre.name}
-                  </div>
+                    text={genre.name}
+                  />
                 ))}
               </div>
             </div>

--- a/src/pages/search.tsx
+++ b/src/pages/search.tsx
@@ -78,6 +78,7 @@ export default function Search() {
 
   const handleRecentWord = ({ word }) => {
     setSearchWord(word);
+    router.push(`search/?word=${word}`);
     setValue(word);
   };
 
@@ -87,6 +88,7 @@ export default function Search() {
 
   const handleRecommendKeyword = (keyword: string) => {
     setValue(keyword);
+    router.push(`search/?word=${keyword}`);
     setSearchWord(keyword);
   };
 

--- a/src/pages/search.tsx
+++ b/src/pages/search.tsx
@@ -42,11 +42,6 @@ interface DefaultProps {
   [key: string]: any;
 }
 
-const components = [
-  { page: 'Intro', component: 'IntroComponent' },
-  { page: 'Result', component: 'StepOneComponent' },
-];
-
 const SearchBox = tw.header<DefaultProps>`
 flex justify-between items-center font-semibold relative h-[64px] mt-7
 `;
@@ -61,8 +56,6 @@ export default function Search() {
   const { data: searchResults } = useGetSearch(searchWord, status);
   const { data: RecentWords } = useGetRecentSearch();
   const { mutate: deleteAllWords } = useDeleteAllWord();
-
-  const [currentIndex, setCurrentIndex] = useState(0);
 
   const handleValue = (e) => {
     setValue(() => e.target.value);
@@ -103,7 +96,6 @@ export default function Search() {
           className="grow-[1]"
           onClick={() => {
             setValue('');
-            setCurrentIndex(0);
             router.back();
           }}
         >

--- a/src/pages/search.tsx
+++ b/src/pages/search.tsx
@@ -91,7 +91,7 @@ export default function Search() {
   };
 
   const page = useMemo(() => {
-    return router.query.page !== undefined ? router.query.page : 'Intro';
+    return router.query.word !== undefined ? router.query.word : 'Intro';
   }, [router.query]);
 
   return (

--- a/src/pages/search.tsx
+++ b/src/pages/search.tsx
@@ -5,7 +5,7 @@ import back from '@public/svg/icons/icon_back.svg';
 import Image from 'next/image';
 import tw from 'tailwind-styled-components';
 import { useRouter } from 'next/router';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import RecentSearchBox from '@components/search/RecentSearchBox';
 import {
@@ -42,6 +42,11 @@ interface DefaultProps {
   [key: string]: any;
 }
 
+const components = [
+  { page: 'Intro', component: 'IntroComponent' },
+  { page: 'Result', component: 'StepOneComponent' },
+];
+
 const SearchBox = tw.header<DefaultProps>`
 flex justify-between items-center font-semibold relative h-[64px] mt-7
 `;
@@ -57,9 +62,7 @@ export default function Search() {
   const { data: RecentWords } = useGetRecentSearch();
   const { mutate: deleteAllWords } = useDeleteAllWord();
 
-  const handleBackBtn = () => {
-    router.back();
-  };
+  const [currentIndex, setCurrentIndex] = useState(0);
 
   const handleValue = (e) => {
     setValue(() => e.target.value);
@@ -69,6 +72,7 @@ export default function Search() {
   };
 
   const onSubmit = () => {
+    router.push(`search/?page=${value}`);
     setSearchWord(value);
   };
 
@@ -86,10 +90,21 @@ export default function Search() {
     setSearchWord(keyword);
   };
 
+  const page = useMemo(() => {
+    return router.query.page !== undefined ? router.query.page : 'Intro';
+  }, [router.query]);
+
   return (
     <Layout>
       <SearchBox>
-        <div className="grow-[1]" onClick={() => handleBackBtn()}>
+        <div
+          className="grow-[1]"
+          onClick={() => {
+            setValue('');
+            setCurrentIndex(0);
+            router.back();
+          }}
+        >
           <Image src={back} alt="back" />
         </div>
         <form className="grow-[5]" onSubmit={handleSubmit(onSubmit)}>
@@ -102,7 +117,7 @@ export default function Search() {
           />
         </form>
       </SearchBox>
-      {searchWord ? (
+      {page !== 'Intro' ? (
         <div>
           <FilterDropdown setStatus={setStatus} />
           <div className="flex flex-wrap justify-between gap-y-2  px-2 py-5">
@@ -129,7 +144,7 @@ export default function Search() {
           </section>
         </div>
       )}
-      {RecentWords?.length && !searchWord ? (
+      {RecentWords?.length && page === 'Intro' && (
         <div>
           <section className="mt-[38px]">
             <div className="flex justify-between">
@@ -154,8 +169,6 @@ export default function Search() {
             </div>
           </section>
         </div>
-      ) : (
-        <div></div>
       )}
     </Layout>
   );

--- a/src/pages/search.tsx
+++ b/src/pages/search.tsx
@@ -72,7 +72,7 @@ export default function Search() {
   };
 
   const onSubmit = () => {
-    router.push(`search/?page=${value}`);
+    router.push(`search/?word=${value}`);
     setSearchWord(value);
   };
 


### PR DESCRIPTION
## 🧑‍💻 PR 내용

1. 낙관적 업데이트를 구현하였습니다.
![스크린샷 2023-02-07 오후 5 14 38](https://user-images.githubusercontent.com/62178788/217188958-8aa5c16f-4800-442a-b95d-b98aff6604c4.png)
QueryKey 객체를 만들어, auction/home/home-view페이지에 따라 old값을 다르게 리턴하여 낙관적 업데이트를 구현해주었습니다.

2. 검색 후, 같은 컴포넌트여서 이전 버튼을 누를 경우 홈으로 가지는 현상이 발생하여, 검색 페이지 안에서 페이지를 구분해주었습니다.
- `router.push(`search/?word=${value}`);`로 이동시킨 후, router.query의 변화값을 활용 + useMemo를 이용하여 기존 값과 다를 경우만 실행시켰습니다
- 참고링크 ; https://kyounghwan01.github.io/blog/React/next/same-page-stack-history/#%E1%84%8B%E1%85%A8%E1%84%89%E1%85%B5-%E1%84%8F%E1%85%A9%E1%84%83%E1%85%B3
![Feb-07-2023 21-08-42](https://user-images.githubusercontent.com/62178788/217241248-8b9a2b95-616e-4995-983f-5ddc9b4052ac.gif)
