### PR TITLE
env 파일대신 CONFIG 사용 및 로그인 안되있으면 온보딩 페이지로 리다이렉트

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -1,8 +1,8 @@
 export const CONFIG = {
+  LOCAL: process.env.NEXT_PUBLIC_LOCAL,
   DOMAIN: process.env.NEXT_PUBLIC_DOMAIN,
   API_BASE_URL: process.env.NEXT_PUBLIC_API_BASE_URL,
   ENV: process.env.NODE_ENV,
-  AUTH_TOKEN_KEY: process.env.NEXT_PUBLIC_AUTH_TOKEN_KEY,
   API_KEYS: {
     KAKAO: process.env.NEXT_PUBLIC_KAKAO_LOGIN_API_KEY,
     NAVER: process.env.NEXT_PUBLIC_NAVER_LOGIN_API_KEY,

--- a/src/apis/_axios/instance.ts
+++ b/src/apis/_axios/instance.ts
@@ -1,18 +1,16 @@
+import { CONFIG } from '@config';
 import axios from 'axios';
 import { getToken, setToken } from '@utils/localStorage/token';
 
 const instance = axios.create({
-  baseURL: process.env.NEXT_PUBLIC_API_BASE_URL,
+  baseURL: CONFIG.API_BASE_URL,
 });
 
 const refreshToken = async () => {
   const refreshToken = getToken().refreshToken;
-  const response = await axios.post(
-    `${process.env.NEXT_PUBLIC_API_BASE_URL}/members/token`,
-    {
-      refreshToken,
-    },
-  );
+  const response = await axios.post(`${CONFIG.API_BASE_URL}/members/token`, {
+    refreshToken,
+  });
   return response.data;
 };
 
@@ -51,8 +49,13 @@ instance.interceptors.response.use(
 
     if (isUnAuthError) {
       if (data?.code === 'TOKEN_INVALID') {
-        alert('세션이 만료되었습니다. 다시 로그인해 주시기 바랍니다.');
-        window.location.href = `${process.env.NEXT_PUBLIC_CLIENT_BASE_URL}/auth/login`;
+        if (CONFIG.ENV === 'development') {
+          alert('세션이 만료되었습니다. 다시 로그인해 주시기 바랍니다.');
+          window.location.href = `${CONFIG.LOCAL}/auth/login`;
+        } else if (CONFIG.ENV === 'production') {
+          alert('세션이 만료되었습니다. 다시 로그인해 주시기 바랍니다.');
+          window.location.href = `${CONFIG.DOMAIN}/auth/login`;
+        }
         return;
       }
 

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -9,7 +9,9 @@ import { QueryClient, QueryClientProvider } from 'react-query';
 
 import type { AppProps } from 'next/app';
 import Loader from '@components/common/Loader';
-import { Suspense } from 'react';
+import { Suspense, useEffect } from 'react';
+import { useRouter } from 'next/router';
+import { getToken } from '@utils/localStorage/token';
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
@@ -25,11 +27,13 @@ const queryClient = new QueryClient({
 const persistor = persistStore(store);
 
 export default function App({ Component, pageProps }: AppProps) {
-  // useEffect(() => {
-  //   if (router.pathname.includes('auth')) return;
-  //   const token = getToken();
-  //   if (!token.accessToken) router.replace('/auth/login');
-  // }, [router]);
+  const router = useRouter();
+  useEffect(() => {
+    if (router.pathname.includes('auth') || router.pathname === '/begin')
+      return;
+    const token = getToken();
+    if (!token.accessToken) router.replace('/begin');
+  }, [router]);
 
   return (
     <div className="flex h-screen w-screen justify-center bg-slate-50 font-Pretendard">

--- a/src/utils/localStorage/token/index.ts
+++ b/src/utils/localStorage/token/index.ts
@@ -1,5 +1,3 @@
-import { CONFIG } from '@config';
-
 import {
   getLocalStorage,
   removeLocalStorage,
@@ -12,7 +10,7 @@ export interface Token {
   roles: string | undefined;
 }
 
-const TOKEN_KEY = CONFIG.AUTH_TOKEN_KEY || '@token';
+const TOKEN_KEY = '@token';
 
 export const getToken = (): Token => {
   const token = getLocalStorage<Token>(TOKEN_KEY, {


### PR DESCRIPTION
## 🧑‍💻 PR 내용
.env의 경우 github에 올라가지 않아 이후 새로 프로젝트 클론시 어떤 환경변수를 사용했는지 확인할 수가 없습니다. 따라서 CONFIG 파일을 만들어서 환경변수들을 명시하고 환경변수 정의는 .env를 사용합니다. 

Next에서 제공하는 환경변수인 process.env.NODE_ENV를 쓰면 development server와 production server를 구분하여 환경변수를 사용할 수 있습니다. 해당 변수값이 'development' 이면 로컬환경  'production'이면 배포환경입니다. 

이제 개발이 거의 마무리 되었으므로 로그인이 안되있으면 온보딩 페이지로 이동하도록 전역 처리 했습니다. 

