### PR TITLE
문의 페이지 훅 생성 & 낙관적 업데이트 & 디자인 수정

### DIFF
--- a/src/@types/profie.d.ts
+++ b/src/@types/profie.d.ts
@@ -1,8 +1,0 @@
-interface Notice {
-  data: number;
-  details: string;
-  id: number;
-  message: string;
-  modifiedDate: string;
-  title: string;
-}

--- a/src/@types/profile.d.ts
+++ b/src/@types/profile.d.ts
@@ -1,0 +1,17 @@
+interface Notice {
+  data: number;
+  details: string;
+  id: number;
+  message: string;
+  modifiedDate: string;
+  title: string;
+}
+
+interface Inquiry {
+  id: number;
+  title: string;
+  content: string;
+  answer: string | null;
+  status: string;
+  date: string;
+}

--- a/src/apis/profile/profileApi.ts
+++ b/src/apis/profile/profileApi.ts
@@ -31,12 +31,22 @@ export class ProfileApi {
   async deletePick(artistId: number) {
     await instance.delete(`/members/preferred-artists/${artistId}`);
   }
-  async getInquiry(): Promise<InquiryForm> {
+  async getInquiry(): Promise<Inquiry[]> {
     const { data } = await instance.get('/members/ask');
     return data;
   }
+  async postInquiry(formData: any) {
+    await instance.post('/members/ask', formData, {
+      headers: {
+        'Content-Type': 'multipart/form-data',
+      },
+    });
+  }
   async patchInquiry(askId: number, formData: any) {
     await instance.patch(`/members/ask/${askId}`, formData);
+  }
+  async deleteInquiry(inquiryId: number) {
+    await instance.delete(`/members/ask/${inquiryId}`);
   }
   async patchKeyword(body: any) {
     const { data } = await instance.patch('/members/keywords', body);

--- a/src/hooks/mutations/useDeleteInquiry.ts
+++ b/src/hooks/mutations/useDeleteInquiry.ts
@@ -1,0 +1,30 @@
+import profileApi from '@apis/profile/profileApi';
+import { queryClient } from 'pages/_app';
+import { useMutation } from 'react-query';
+
+const useDeleteInquiry = (inquiryId: number) => {
+  return useMutation<any, Error>(
+    'useDeleteInquiry',
+    () => profileApi.deleteInquiry(inquiryId),
+    {
+      onMutate: async () => {
+        await queryClient.cancelQueries({ queryKey: ['useDeleteInquiry'] });
+        const previousValue = queryClient.getQueryData(['useGetInquiry']);
+        queryClient.setQueryData(['useGetInquiry'], (old: any) =>
+          old.filter((t) => t.id !== inquiryId),
+        );
+        return { previousValue };
+      },
+      onError: (context: any) => {
+        queryClient.setQueryData(['useGetInquiry'], context.previousValue);
+      },
+      onSettled: () => {
+        queryClient.invalidateQueries({
+          queryKey: ['useGetInquiry'],
+        });
+      },
+    },
+  );
+};
+
+export default useDeleteInquiry;

--- a/src/hooks/mutations/usePatchInquiry.ts
+++ b/src/hooks/mutations/usePatchInquiry.ts
@@ -1,0 +1,32 @@
+import profileApi from '@apis/profile/profileApi';
+import { queryClient } from 'pages/_app';
+import { useMutation } from 'react-query';
+
+const usePatchInquiry = (inquiryId: number, formData: any) => {
+  return useMutation<any, Error>(
+    'usePatchInquiry',
+    () => profileApi.patchInquiry(inquiryId, formData),
+    {
+      onMutate: async () => {
+        await queryClient.cancelQueries({ queryKey: ['usePatchInquiry'] });
+        const previousValue = queryClient.getQueryData(['useGetInquiry']);
+        queryClient.setQueryData(['useGetInquiry'], (old: any) => {
+          return {
+            ...old,
+            formData,
+          };
+        });
+        return { previousValue };
+      },
+      onError: (context: any) => {
+        queryClient.setQueryData(['useGetInquiry'], context.previousValue);
+      },
+      onSettled: () => {
+        queryClient.invalidateQueries({
+          queryKey: ['useGetInquiry'],
+        });
+      },
+    },
+  );
+};
+export default usePatchInquiry;

--- a/src/hooks/mutations/usePostInquiry.ts
+++ b/src/hooks/mutations/usePostInquiry.ts
@@ -1,0 +1,35 @@
+import profileApi from '@apis/profile/profileApi';
+import { queryClient } from 'pages/_app';
+import { useMutation } from 'react-query';
+
+const usePostInquiry = (formData: any) => {
+  return useMutation<any, Error>(
+    'usePostInquiry',
+    () => profileApi.postInquiry(formData),
+    {
+      retry: false,
+      onMutate: async () => {
+        await queryClient.cancelQueries({ queryKey: ['usePostInquiry'] });
+        const previousValue = queryClient.getQueryData(['useGetInquiry']);
+        queryClient.setQueryData(['useGetInquiry'], (old: any) => {
+          console.log(old);
+          return {
+            ...old,
+            formData,
+          };
+        });
+        return { previousValue };
+      },
+      onError: (context: any) => {
+        queryClient.setQueryData(['useGetInquiry'], context.previousValue);
+      },
+      onSettled: () => {
+        queryClient.invalidateQueries({
+          queryKey: ['useGetInquiry'],
+        });
+      },
+    },
+  );
+};
+
+export default usePostInquiry;

--- a/src/hooks/queries/useGetInquiry.ts
+++ b/src/hooks/queries/useGetInquiry.ts
@@ -1,16 +1,13 @@
 import { useQuery } from 'react-query';
 import profileApi from '@apis/profile/profileApi';
 
-interface Inquiry {
-  date: string;
-  time: string;
-  title: string;
-  content: string;
-  status: string;
-  answer: string;
-  id: number;
-}
-
 export default function useGetInquiry() {
-  return useQuery<any, Error>('useInquiry', () => profileApi.getInquiry());
+  return useQuery<Inquiry[], Error>(
+    'useGetInquiry',
+    () => profileApi.getInquiry(),
+    {
+      retry: false,
+      refetchOnWindowFocus: false,
+    },
+  );
 }

--- a/src/pages/profile/inquiry.tsx
+++ b/src/pages/profile/inquiry.tsx
@@ -109,10 +109,10 @@ export default function Inquiry() {
       />
       <Tab.Group selectedIndex={selectedIndex} onChange={setSelectedIndex}>
         <Tab.List>
-          <Tab className="mb-[28px] h-[32px] w-1/2 border-[#191919] text-16 font-bold ui-selected:border-b-[2px] ui-selected:text-[#191919] ui-not-selected:border-b-[2px] ui-not-selected:border-[#EDEDED] ui-not-selected:text-[#999999]">
+          <Tab className="h-[52px] w-1/2 border-[#191919] text-16 font-medium ui-selected:border-b-[2px] ui-selected:text-[#191919] ui-not-selected:border-b ui-not-selected:border-[#EDEDED] ui-not-selected:text-[#999999]">
             문의하기
           </Tab>
-          <Tab className="h-[32px] w-1/2 border-[#191919] text-16 font-bold ui-selected:border-b-[2px] ui-selected:text-[#191919] ui-not-selected:border-b-[2px] ui-not-selected:border-[#EDEDED] ui-not-selected:text-[#999999] ">
+          <Tab className="h-[52px] w-1/2 border-[#191919] text-16 font-medium ui-selected:border-b-[2px] ui-selected:text-[#191919] ui-not-selected:border-b ui-not-selected:border-[#EDEDED] ui-not-selected:text-[#999999]">
             문의내역확인
           </Tab>
         </Tab.List>
@@ -120,7 +120,7 @@ export default function Inquiry() {
           <Tab.Panel>
             <form autoComplete="off" onSubmit={handleSubmit(onSubmit)}>
               <section className="mb-5 flex flex-col">
-                <div className="mb-3 flex justify-between">
+                <div className="mb-3 mt-6 flex justify-between">
                   <label
                     htmlFor="title"
                     className="text-14 font-bold leading-8"

--- a/src/pages/profile/inquiry.tsx
+++ b/src/pages/profile/inquiry.tsx
@@ -1,4 +1,3 @@
-import instance from '@apis/_axios/instance';
 import Button from '@components/common/Button';
 import Layout from '@components/common/Layout';
 import Navigate from '@components/common/Navigate';
@@ -11,6 +10,7 @@ import { Tab } from '@headlessui/react';
 import { useForm } from 'react-hook-form';
 import { useEffect, useState } from 'react';
 import { formatBytes } from '@utils/formatBytes';
+import usePostInquiry from '@hooks/mutations/usePostInquiry';
 
 interface InquiryForm {
   title: string;
@@ -29,10 +29,12 @@ interface InquiryForm {
 }
 
 export default function Inquiry() {
+  const [postData, setPostData] = useState<FormData>();
   const [fileLists, setFileLists] = useState<File[]>([]);
   const [fileSize, setFileSize] = useState<number>(0);
   const [selectedIndex, setSelectedIndex] = useState<number>(0);
-  const { data, refetch: inquiryRefetch } = useGetInquiry();
+  const { mutate: postInquiry } = usePostInquiry(postData);
+  const { data } = useGetInquiry();
 
   const router = useRouter();
   const handleLeftButton = () => {
@@ -49,13 +51,6 @@ export default function Inquiry() {
     });
     setFileLists(newFileLists);
     setFileSize((prev) => prev - targetSize);
-  };
-
-  const handleRemoveInquiry = async (targetId: number) => {
-    const response = await instance.delete(`/members/ask/${targetId}`);
-    inquiryRefetch();
-
-    return;
   };
 
   const clearForm = () => {
@@ -85,14 +80,25 @@ export default function Inquiry() {
     const formData = new FormData();
     formData.append('title', title);
     formData.append('content', content);
-    for (let i = 0; i < image.length; i++) {
-      formData.append('image', image[i]);
+    if (image.length) {
+      for (let i = 0; i < image.length; i++) {
+        formData.append('image', image[i]);
+        console.log(image[i]);
+      }
+    } else {
+      formData.append('image', new File([''], ''));
     }
-    const response = await instance.post('/members/ask', formData);
+    console.log(image);
+    setPostData(() => formData);
     clearForm();
-    inquiryRefetch();
     setSelectedIndex(1);
   };
+
+  useEffect(() => {
+    if (postData) {
+      postInquiry();
+    }
+  }, [postData]);
 
   return (
     <Layout>
@@ -103,10 +109,10 @@ export default function Inquiry() {
       />
       <Tab.Group selectedIndex={selectedIndex} onChange={setSelectedIndex}>
         <Tab.List>
-          <Tab className="mb-[28px] h-[32px] w-1/2 border-[#191919] text-16 font-bold ui-selected:border-b-[2px] ui-selected:text-[#191919] ui-not-selected:border-b-[1px] ui-not-selected:border-[#EDEDED] ui-not-selected:text-[#999999]">
+          <Tab className="mb-[28px] h-[32px] w-1/2 border-[#191919] text-16 font-bold ui-selected:border-b-[2px] ui-selected:text-[#191919] ui-not-selected:border-b-[2px] ui-not-selected:border-[#EDEDED] ui-not-selected:text-[#999999]">
             문의하기
           </Tab>
-          <Tab className="h-[32px] w-1/2 border-[#191919] text-16 font-bold ui-selected:border-b-[2px] ui-selected:text-[#191919] ui-not-selected:border-b-[1px] ui-not-selected:border-[#EDEDED] ui-not-selected:text-[#999999] ">
+          <Tab className="h-[32px] w-1/2 border-[#191919] text-16 font-bold ui-selected:border-b-[2px] ui-selected:text-[#191919] ui-not-selected:border-b-[2px] ui-not-selected:border-[#EDEDED] ui-not-selected:text-[#999999] ">
             문의내역확인
           </Tab>
         </Tab.List>
@@ -176,7 +182,7 @@ export default function Inquiry() {
                 <div>
                   <div className="flex">
                     <label htmlFor="fileImage">
-                      <div className="mr-0 flex h-[60px] w-[60px] flex-col items-center justify-center rounded border-[1px] border-[#DBDBDB]">
+                      <div className="mr-0 flex h-[60px] w-[60px] cursor-pointer flex-col items-center justify-center rounded border-[1px] border-[#DBDBDB]">
                         <Image
                           src="/svg/icons/icon_camera_black.svg"
                           alt="camera"
@@ -230,16 +236,16 @@ export default function Inquiry() {
                   {...register('image')}
                 />
               </section>
-              <section className="mt-[75px] flex w-full justify-between">
+              <section className="mt-[75px] mb-[45px] flex w-full justify-between">
                 <Button
                   kind="outlined"
                   text="취소"
-                  className="h-[48px] w-[150px]"
+                  className="h-[48px] w-[46%]"
                 />
                 <Button
                   type="submit"
                   text="문의접수"
-                  className="h-[48px] w-[150px]"
+                  className="h-[48px] w-[46%]"
                 />
               </section>
             </form>
@@ -248,11 +254,7 @@ export default function Inquiry() {
             {data?.length ? (
               <div>
                 {data?.map((inquiry, idx) => (
-                  <InquiryItem
-                    key={'' + idx}
-                    inquiry={inquiry}
-                    handler={handleRemoveInquiry}
-                  />
+                  <InquiryItem key={'' + idx} inquiry={inquiry} />
                 ))}
                 <div className="mt-[14px] text-center text-14 text-[#999999]">
                   최근 1년간 문의내역만 조회 가능합니다.


### PR DESCRIPTION
## 🧑‍💻 PR 내용

문의 페이지에서 기존 instance를 사용하던 방법에서 mutation을 사용하는 방법으로 교체했습니다.
문의 접수,수정에서 이미지가 없을시에 발생했던 오류 수정을 완료하고, 문의 삭제에 낙관적 업데이트를 구현했습니다.
문의 접수와 수정에서는 formData를 통한 낙관적 업데이트를 구현하지 못했는데 이 부분은 같이 고민해봤으면 좋겠습니다.

## 📸 스크린샷

![녹화_2023_02_08_13_06_54_673](https://user-images.githubusercontent.com/79186378/217435349-3f26d916-c99e-4c10-9008-24c811b72b08.gif)
