### PR TITLE
모바일 layout issue 해결

### DIFF
--- a/src/components/common/Tab.tsx
+++ b/src/components/common/Tab.tsx
@@ -35,7 +35,7 @@ interface DefaultProps {
 }
 
 const TabBox = tw.footer<DefaultProps>`
- absolute bottom-0 bg-white max-w-[420px] flex justify-center z-50 py-2 inset-x-0 m-auto px-3
+ fixed inset-x-0 bottom-0 bg-white max-w-[420px] flex justify-center z-50 py-2 inset-x-0 m-auto px-3
 `;
 
 const TabList = tw.div<DefaultProps>`flex w-full`;


### PR DESCRIPTION
## 🧑‍💻 PR 내용
chrome mobile이랑 실제 핸드폰 접속시 홈에서 탭 위치가 어긋나는 이슈가 있습니다.  

찾아보니 absolute로 고정하면 생기는 경우가 있다고 하여 일단 fixed로 viewport에 고정시키고 다시 재배포된 후 확인 해봐야 할거 같습니다. 
## 📸 스크린샷
오류화면
![KakaoTalk_20230208_143202571](https://user-images.githubusercontent.com/92621861/217443142-f2b3ce70-533d-4a9c-a600-d3d0b8c6b10a.jpg)
