### PR TITLE
작품등록 버튼 fixed로 레이아웃 수정

### DIFF
--- a/src/components/home/FloatButton.tsx
+++ b/src/components/home/FloatButton.tsx
@@ -12,7 +12,7 @@ export default function FloatButton() {
       onClick={() => {
         router.push('/home/post');
       }}
-      className="sticky bottom-20 z-50  m-auto mr-0 h-[72px] w-[72px] cursor-pointer"
+      className="insex-x-0 fixed bottom-20 z-50  m-auto mr-0 h-[72px] w-[72px] cursor-pointer"
     />
   );
 }


### PR DESCRIPTION
## 🧑‍💻 PR 내용
모바일 기기로 접속시 작품등록 버튼이 하단 탭에 가려져서 sticky 대신 하단탭과 동일하게 fiexd 속성으로 viewport에 고정시켰습니다. 

## 📸 스크린샷
![KakaoTalk_20230208_153739468](https://user-images.githubusercontent.com/92621861/217453363-1c9ad270-f116-43ca-b5f2-3be5331c4229.jpg)

