### PR TITLE
알림페이지 디자인 수정

### DIFF
--- a/src/components/notice/NoticeItem.tsx
+++ b/src/components/notice/NoticeItem.tsx
@@ -26,6 +26,8 @@ export default function NoticeItem({ notice }: NoticeItemProps) {
     title += ' 🎉';
   }
 
+  console.log(notice);
+
   const icon = {
     '작가 등록 완료 🎉': ['post', '/profile/edit'],
     '작품 등록 완료 🎉': ['post', `/auction/${notice.data}`],
@@ -53,7 +55,7 @@ export default function NoticeItem({ notice }: NoticeItemProps) {
         className="mr-3"
       />
       <section
-        className="flex cursor-pointer flex-col leading-5"
+        className="flex cursor-pointer flex-col leading-5 max-[400px]:w-[230px] max-[355px]:w-[200px]"
         onClick={() => {
           router.push(icon[title][1]);
         }}
@@ -67,7 +69,7 @@ export default function NoticeItem({ notice }: NoticeItemProps) {
         alt="close"
         width={25}
         height={0}
-        className="cursor-pointer min-[400px]:ml-6"
+        className="cursor-pointer"
         onClick={() => deleteNotice()}
       />
     </li>

--- a/src/components/notice/NoticeItem.tsx
+++ b/src/components/notice/NoticeItem.tsx
@@ -54,7 +54,7 @@ export default function NoticeItem({ notice }: NoticeItemProps) {
           className="mr-3"
         />
         <section
-          className="flex cursor-pointer flex-col leading-5 max-[400px]:w-[230px] max-[355px]:w-[200px]"
+          className="flex cursor-pointer flex-col leading-5"
           onClick={() => {
             router.push(icon[title][1]);
           }}

--- a/src/components/notice/NoticeItem.tsx
+++ b/src/components/notice/NoticeItem.tsx
@@ -44,26 +44,28 @@ export default function NoticeItem({ notice }: NoticeItemProps) {
   };
 
   return (
-    <li className="text-medium relative flex border-b-[1px] py-3 last:border-none">
-      <Image
-        alt="notice_icon"
-        src={`/svg/icons/notice/icon_notice_${
-          icon[title] && icon[title][0]
-        }.svg`}
-        width={37}
-        height={37}
-        className="mr-3"
-      />
-      <section
-        className="flex cursor-pointer flex-col leading-5 max-[400px]:w-[230px] max-[355px]:w-[200px]"
-        onClick={() => {
-          router.push(icon[title][1]);
-        }}
-      >
-        <p className="text-[12px] font-bold">{title}</p>
-        <p className="flex justify-between text-[14px]">{notice.message}</p>
-        <p className="text-[10px] text-[#999999]">{modifiedDate}</p>
-      </section>
+    <li className="text-medium relative flex justify-between border-b-[1px] py-3 last:border-none">
+      <div className="flex">
+        <Image
+          alt="notice_icon"
+          src={`/svg/icons/notice/icon_notice_${
+            icon[title] && icon[title][0]
+          }.svg`}
+          width={37}
+          height={37}
+          className="mr-3"
+        />
+        <section
+          className="flex cursor-pointer flex-col leading-5 max-[400px]:w-[230px] max-[355px]:w-[200px]"
+          onClick={() => {
+            router.push(icon[title][1]);
+          }}
+        >
+          <p className="text-[12px] font-bold">{title}</p>
+          <p className="flex justify-between text-[14px]">{notice.message}</p>
+          <p className="text-[10px] text-[#999999]">{modifiedDate}</p>
+        </section>
+      </div>
       <Image
         src="/svg/icons/icon_grayClose.svg"
         alt="close"

--- a/src/components/notice/NoticeItem.tsx
+++ b/src/components/notice/NoticeItem.tsx
@@ -26,8 +26,6 @@ export default function NoticeItem({ notice }: NoticeItemProps) {
     title += ' 🎉';
   }
 
-  console.log(notice);
-
   const icon = {
     '작가 등록 완료 🎉': ['post', '/profile/edit'],
     '작품 등록 완료 🎉': ['post', `/auction/${notice.data}`],


### PR DESCRIPTION
## 🧑‍💻 PR 내용

기존에 알림 페이지 수정했던 부분 알림 길이가 각각 다르다는 것을 기준으로 디자인 작업을 해야했는데,
알림 길이가 다른 경우 삭제 버튼 위치가 달라져서 html 틀을 수정했습니다.

## 📸 스크린샷

기존 화면

![image](https://user-images.githubusercontent.com/79186378/217572688-8d2d7a17-3a14-4cd5-ae90-5f3968d8b012.png)

변경 후

![녹화_2023_02_09_00_38_48_706](https://user-images.githubusercontent.com/79186378/217577883-ccb151c8-82dc-47df-972b-ec8076419ccb.gif)
