### PR TITLE
작품/경매 상세보기 수정

### DIFF
--- a/src/components/auction/ArtWorkItem.tsx
+++ b/src/components/auction/ArtWorkItem.tsx
@@ -27,7 +27,10 @@ export default function ArtWorkItem({
     <ArtWorkItemTag
       {...rest}
       onClick={() => {
-        router.push(`/auction/${id}`);
+        router.push({
+          pathname: `/auction/view`,
+          query: { id },
+        });
       }}
     >
       <section className="relative h-[200px] overflow-hidden">

--- a/src/hooks/queries/auction/useGetNowAuctionArtworkList.ts
+++ b/src/hooks/queries/auction/useGetNowAuctionArtworkList.ts
@@ -5,7 +5,12 @@ const useGetNowAuctionArtworkList = () => {
   return useQuery<NowAuctionArtworkList, Error>(
     'useGetNowAuctionArtworkList',
     () => auctionApi.getNowAuctionArtworkList(),
-    { retry: false, refetchOnWindowFocus: false },
+    {
+      retry: false,
+      refetchOnWindowFocus: false,
+      suspense: false,
+      useErrorBoundary: false,
+    },
   );
 };
 

--- a/src/pages/auction/[id].tsx
+++ b/src/pages/auction/[id].tsx
@@ -254,8 +254,29 @@ export default function Detail() {
               </div>
             </div>
           </article>
+          <article>
+            {artWork?.images.slice(1).map((image: string, idx: number) => (
+              <div key={idx} className="relative mt-8 aspect-square w-full">
+                <Image
+                  src={image}
+                  alt="artwork"
+                  fill
+                  className="object-contain"
+                  priority
+                />
+              </div>
+            ))}
+          </article>
 
-          <article className="relative h-[457px] w-full">
+          {/* <article className="relative h-[457px] w-full">
+            <div>
+              <Image
+                src="/svg/example/guarantee_empty.svg"
+                alt="guarantee"
+                width={327}
+                height={457}
+              />
+            </div>
             <Image
               alt="guarantee"
               src={artWork?.guaranteeImage || '/svg/example/guarantee.svg'}
@@ -263,7 +284,7 @@ export default function Detail() {
               className="object-contain"
               priority
             />
-          </article>
+          </article> */}
           <div className="h-[7rem]" />
         </section>
       </Layout>

--- a/src/pages/auction/[id].tsx
+++ b/src/pages/auction/[id].tsx
@@ -242,7 +242,7 @@ export default function Detail() {
             </div>
             <div className="mt-4">
               <p className="text-14">{artWork?.description}</p>
-              <div className="mt-4">
+              <div className="mt-4 flex flex-wrap">
                 {artWork?.keywords?.map((keyword: string, idx: number) => (
                   <span
                     key={idx}

--- a/src/pages/auction/[id].tsx
+++ b/src/pages/auction/[id].tsx
@@ -199,7 +199,7 @@ export default function Detail() {
             </p>
             <p>
               <span className="inline-block w-[6rem] text-[#767676]">재료</span>
-              <span className="text-[#191919]">재료</span>
+              <span className="text-[#191919]">{artWork?.material}</span>
             </p>
             <p>
               <span className="inline-block w-[6rem] text-[#767676]">액자</span>

--- a/src/pages/auction/view.tsx
+++ b/src/pages/auction/view.tsx
@@ -10,7 +10,7 @@ import useDeletePrefer from '@hooks/mutations/useDeletePrefer';
 import { useCountDown } from '@hooks/useCountDown';
 import useGetProfile from '@hooks/queries/useGetProfile';
 
-export default function Detail() {
+export default function View() {
   const router = useRouter();
 
   const artWorkId = Number(router.query.id);


### PR DESCRIPTION
## 🧑‍💻 PR 내용
작품 상세
- 재료 표기되도록 수정
- 진행중인 경매가 없을때 앱이 다운되는 오류 해결
- 키워드 폭 넘칠때 짤리는 현상 수정
- 작품 상세 후 작품 사진 보여주기
- 동적 라우팅 대신 query로 id값 전달하는 것으로 수정
- 작품보증서 사진을 현재는 서버와 서명사진을 주고 받고 있는데 서명이 들어간 작품보증서 사진을 주고받아야 작품정보와 서명이 포함된 작품보증서사진을 보여줄수 있을거 같습니다. (QA 칸반에서는 pending으로 옮겨두었습니다.)

