### PR TITLE
activity 패딩 조절

### DIFF
--- a/src/components/profile/Activity.tsx
+++ b/src/components/profile/Activity.tsx
@@ -29,7 +29,9 @@ export default function Activity({ text, path, icon }: ActivityBoxProps) {
       }}
     >
       <Image src={icon} alt={`${icon}`} width={20} height={20} />
-      <span className="pt-[12px] text-12 text-[#767676]">{text}</span>
+      <span className="pt-[12px] text-12 text-[#767676] max-[400px]:pt-[6px]">
+        {text}
+      </span>
     </ActivityBox>
   );
 }


### PR DESCRIPTION
## 🧑‍💻 PR 내용

휴대폰 화면일때 activity 컴포넌트에서 아이콘과 텍스트 간격이 너무 벌어져있는 현상 수정

피그마에서는 12px이 맞지만, 휴대폰 화면상 400px 이하인 경우에 6px로 조정했습니다.

## 📸 스크린샷


