### PR TITLE
찜작품 이미지 비율 수정

### DIFF
--- a/src/components/profile/WishCard.tsx
+++ b/src/components/profile/WishCard.tsx
@@ -29,9 +29,9 @@ export default function WishCard({ wish }) {
         router.push(`/auction/view?id=${wish.id}`);
       }}
     >
-      <div className="relative h-28  bg-gray-300">
+      <div className="relative h-28  rounded-t-lg bg-gray-300">
         <Image
-          className="absolute top-3 right-3 rounded-t-lg"
+          className="rounded-t-lg object-cover"
           src={wish?.image || '/svg/icons/icon_favorite.svg'}
           alt="favorite"
           fill


### PR DESCRIPTION
## 🧑‍💻 PR 내용

찜작품 이미지를 object-contain으로 수정했습니다.
추가적으로 이미지의 부모태그에 border-radius가 적용되어 있지않아서 해당사항도 추가했습니다.

## 📸 스크린샷

![image](https://user-images.githubusercontent.com/79186378/218098973-c5ca9bdb-9390-476c-ad0e-9e7918708c52.png)

