### PR TITLE
홈화면 전시작품 겹침 수정 & home/view 레이아웃 수정

### DIFF
--- a/src/apis/profile/profileApi.type.ts
+++ b/src/apis/profile/profileApi.type.ts
@@ -26,6 +26,7 @@ export interface Notice {
 }
 export interface IsNoticeForm {
   newNotification: boolean;
+  isArtist: boolean;
 }
 export interface Role {
   roles: string;

--- a/src/components/common/NoticeIcon.tsx
+++ b/src/components/common/NoticeIcon.tsx
@@ -21,15 +21,14 @@ export default React.memo(function NoticeIcon({
   const router = useRouter();
   const { data } = useGetIsNotice();
   const isNotice = data?.newNotification;
-  // const isArtist = data?.isArtist;
-  // if (isArtist === true) {
-  //   console.log('전환');
-  //   setToken({
-  //     accessToken: getToken().accessToken,
-  //     refreshToken: getToken().refreshToken,
-  //     roles: 'ROLE_ARTIST',
-  //   });
-  // }
+  const isArtist = data?.isArtist;
+  if (isArtist === true && getToken().roles !== 'ROLE_ARTIST') {
+    setToken({
+      accessToken: getToken().accessToken,
+      refreshToken: getToken().refreshToken,
+      roles: 'ROLE_ARTIST',
+    });
+  }
   return (
     <NoticeIconTag {...rest}>
       {isSearch ? (

--- a/src/components/common/NoticeIcon.tsx
+++ b/src/components/common/NoticeIcon.tsx
@@ -3,6 +3,7 @@ import Image from 'next/image';
 import React from 'react';
 import { useRouter } from 'next/router';
 import useGetIsNotice from '@hooks/queries/useGetIsNotice';
+import { getToken, setToken } from '@utils/localStorage/token';
 
 interface NoticeIconProps {
   isSearch?: boolean;
@@ -20,6 +21,15 @@ export default React.memo(function NoticeIcon({
   const router = useRouter();
   const { data } = useGetIsNotice();
   const isNotice = data?.newNotification;
+  // const isArtist = data?.isArtist;
+  // if (isArtist === true) {
+  //   console.log('전환');
+  //   setToken({
+  //     accessToken: getToken().accessToken,
+  //     refreshToken: getToken().refreshToken,
+  //     roles: 'ROLE_ARTIST',
+  //   });
+  // }
   return (
     <NoticeIconTag {...rest}>
       {isSearch ? (

--- a/src/components/home/ExhibitionItem.tsx
+++ b/src/components/home/ExhibitionItem.tsx
@@ -25,7 +25,7 @@ export default React.memo(function ExhibitionItem({
   };
   return (
     <div
-      className="relative h-[197px] w-[158px] rounded"
+      className="relative h-[197px] w-[158px] rounded max-[400px]:h-[175px] max-[400px]:w-[145px]"
       onClick={() => {
         router.push({
           pathname: '/exhibition/detail',
@@ -38,11 +38,8 @@ export default React.memo(function ExhibitionItem({
         alt="notification"
         fill
         sizes="1000"
-        style={{
-          objectFit: 'cover',
-        }}
         priority
-        className="rounded"
+        className="rounded object-cover"
         quality={100}
       />
 

--- a/src/pages/home/index.tsx
+++ b/src/pages/home/index.tsx
@@ -47,7 +47,6 @@ export default function Home() {
   const { data: userInfo } = useGetProfile();
   const { data: auctionList } = useGetAuction() || {};
   const { data: pastAuctionList } = useGetPastAuction() || {};
-
   return (
     <>
       <Layout>
@@ -124,12 +123,12 @@ export default function Home() {
             ))}
         </KeywordSection>
 
-        <section className="mb-12 ">
+        <section className="mb-12 flex justify-center">
           <Swiper
             modules={[Autoplay, Navigation, Scrollbar]}
             navigation
             scrollbar={{ draggable: true }}
-            spaceBetween={2}
+            spaceBetween={0}
             slidesPerView={2.1}
             autoplay={{ delay: 5000, disableOnInteraction: false }}
           >

--- a/src/pages/home/view.tsx
+++ b/src/pages/home/view.tsx
@@ -65,7 +65,7 @@ export default function View() {
         </p>
         <p className="text-[20px] font-bold text-[#191919]">이번 주 전시작품</p>
       </div>
-      <div className="mt-6 flex w-full flex-wrap justify-center gap-y-5 gap-x-5">
+      <div className="mt-6 grid w-full grid-cols-2 content-center items-center justify-items-center gap-y-5">
         {artworkLists?.map((art) => (
           <ExhibitionItem
             key={art.id}
@@ -76,19 +76,19 @@ export default function View() {
             pick={art.pick}
           />
         ))}
-        <div ref={target} className="flex h-[100px] w-full justify-center">
-          {isLoaded && (
-            <div className="mt-5 flex h-[30px] items-center justify-center">
-              <div className="grid gap-2">
-                <div className="flex items-center justify-center space-x-2">
-                  <div className="h-3 w-3 animate-bounce1 rounded-full bg-brand"></div>
-                  <div className="h-3 w-3 animate-bounce2 rounded-full bg-brand"></div>
-                  <div className="h-3 w-3 animate-bounce3 rounded-full bg-brand"></div>
-                </div>
+      </div>
+      <div ref={target} className="flex h-[100px] w-full justify-center">
+        {isLoaded && (
+          <div className="mt-5 flex h-[30px] items-center justify-center">
+            <div className="grid gap-2">
+              <div className="flex items-center justify-center space-x-2">
+                <div className="h-3 w-3 animate-bounce1 rounded-full bg-brand"></div>
+                <div className="h-3 w-3 animate-bounce2 rounded-full bg-brand"></div>
+                <div className="h-3 w-3 animate-bounce3 rounded-full bg-brand"></div>
               </div>
             </div>
-          )}
-        </div>
+          </div>
+        )}
       </div>
     </Layout>
   );


### PR DESCRIPTION
## 🧑‍💻 PR 내용

휴대폰으로 볼 때 홈화면에서 전시작품이 겹치는 현상 수정했습니다.
휴대폰으로 전체보기했을 때 전시작품이 하나씩 나열되는 현상, 웹으로 전체보기 했을때 작품 수가 홀수인경우 마지막 작품이
가운데 정렬되는 현상을 Grid로 수정했습니다.

추가적으로 작가전환시에 localStorage의 ROLE을 변경하려고했지만
NoticeIcon 컴포넌트 내에서 useGetIsNotice를 통해 받아온 data에서 isArtist를 통해 작가전환을 시도했습니다.
localStorage에는 잘 반영이 되지만 새로고침을 해야만 변경된 localStorage 에서 ROLE을 다시 받아오는것 같습니다.

추가적으로 NoticeIcon 컴포넌트 내에서 isArtist가 true이면 작가로 전환하는 로직을 수행하게 되는데
전환이 이루어진 후에도 불필요하게 setToken을 통해 localStorage를 조작하게됩니다.

이 부분은 어떻게 처리하면 좋을지 다 같이 고민해보면 좋을것 같아 일단은 주석처리 해놨습니다.


## 📸 스크린샷


![녹화_2023_02_13_19_17_06_391](https://user-images.githubusercontent.com/79186378/218474636-7c760b4e-e296-478f-8eaa-d4821ddca753.gif)
![녹화_2023_02_13_19_17_39_48](https://user-images.githubusercontent.com/79186378/218474653-fc0743c2-a028-4061-864d-3d07353c8225.gif)
