### PR TITLE
검색페이지 작품 크기 반응형 & Grid 정렬

### DIFF
--- a/src/components/search/SearchItem.tsx
+++ b/src/components/search/SearchItem.tsx
@@ -19,7 +19,7 @@ export default function SearchItem({ artwork }: ArtworkForm) {
     }
   };
   return (
-    <div className="relative h-[197px] w-[158px] rounded">
+    <div className="relative h-[197px] w-[158px] rounded max-[400px]:h-[175px] max-[400px]:w-[145px]">
       <Image
         src={artwork.image}
         alt="notification"

--- a/src/pages/search.tsx
+++ b/src/pages/search.tsx
@@ -131,7 +131,7 @@ export default function Search() {
       {!!page ? (
         <div>
           <FilterDropdown setStatus={setStatus} />
-          <div className="flex flex-wrap justify-between gap-y-2  px-2 py-5">
+          <div className="mt-6 grid grid-cols-2 items-center justify-items-center gap-y-5">
             {searchResults?.map((artwork: SearchArtWork, idx) => (
               <SearchItem artwork={artwork} key={+idx} />
             ))}


### PR DESCRIPTION
## 🧑‍💻 PR 내용

홈 화면 전시작품 전체보기와 같이
검색페이지 작품 또한 휴대폰 크기에 따라 크기를 반응형으로 조정하고
검색결과를 Grid 정렬로 수정했습니다.

## 📸 스크린샷


