### PR TITLE
문의 페이지 디자인 수정 & 문의 등록 훅 수정

### DIFF
--- a/src/components/inquiry/InquiryItem.tsx
+++ b/src/components/inquiry/InquiryItem.tsx
@@ -82,7 +82,7 @@ export default function InquiryItem({ inquiry }: InquiryItemForm) {
         <div className="mt-5 flex justify-between">
           <div className="flex justify-start">
             <span className="mr-2 w-[70px] rounded-[39px] border-[1px] border-[#DBDBDB] py-[1px] text-center text-12 font-semibold text-[#767676] ">
-              {inquiry.status === 'WAITING' && '대기중'}
+              {inquiry.status === 'WAITING' ? '대기중' : '답변완료'}
             </span>
             <span className="text-14 text-[#999999]">{inquiry.date}</span>
           </div>
@@ -245,7 +245,7 @@ export default function InquiryItem({ inquiry }: InquiryItemForm) {
           </div>
         )}
         <Disclosure.Panel className="pt-5 text-14 text-gray-500">
-          <div className="flex w-full items-center bg-[#F8F8FA] py-4 px-2">
+          <div className="flex w-full flex-col bg-[#F8F8FA] py-4 px-2">
             <section className="flex">
               <div className="mr-2 flex h-6 w-6 items-center justify-center rounded-full bg-brand">
                 <Image
@@ -258,7 +258,7 @@ export default function InquiryItem({ inquiry }: InquiryItemForm) {
               <div className="w-[270px]">{inquiry.content}</div>
             </section>
             {inquiry.answer && (
-              <section className="flex">
+              <section className="mt-3 flex">
                 <div className="mr-2 flex h-6 w-6 items-center justify-center rounded-full bg-brand">
                   <Image
                     src="/svg/icons/icon_logo_brand.svg"

--- a/src/hooks/mutations/usePostInquiry.ts
+++ b/src/hooks/mutations/usePostInquiry.ts
@@ -8,21 +8,6 @@ const usePostInquiry = (formData: any) => {
     () => profileApi.postInquiry(formData),
     {
       retry: false,
-      onMutate: async () => {
-        await queryClient.cancelQueries({ queryKey: ['usePostInquiry'] });
-        const previousValue = queryClient.getQueryData(['useGetInquiry']);
-        queryClient.setQueryData(['useGetInquiry'], (old: any) => {
-          console.log(old);
-          return {
-            ...old,
-            formData,
-          };
-        });
-        return { previousValue };
-      },
-      onError: (context: any) => {
-        queryClient.setQueryData(['useGetInquiry'], context.previousValue);
-      },
       onSettled: () => {
         queryClient.invalidateQueries({
           queryKey: ['useGetInquiry'],

--- a/src/pages/profile/inquiry.tsx
+++ b/src/pages/profile/inquiry.tsx
@@ -256,7 +256,7 @@ export default function Inquiry() {
                 {data?.map((inquiry, idx) => (
                   <InquiryItem key={'' + idx} inquiry={inquiry} />
                 ))}
-                <div className="mt-[14px] text-center text-14 text-[#999999]">
+                <div className="my-[14px] text-center text-14 text-[#999999]">
                   최근 1년간 문의내역만 조회 가능합니다.
                 </div>
               </div>

--- a/src/pages/profile/inquiry.tsx
+++ b/src/pages/profile/inquiry.tsx
@@ -4,6 +4,7 @@ import Navigate from '@components/common/Navigate';
 import FileItem from '@components/inquiry/FileItem';
 import InquiryItem from '@components/inquiry/InquiryItem';
 import useGetInquiry from '@hooks/queries/useGetInquiry';
+import Loader from '@components/common/Loader';
 import Image from 'next/image';
 import { useRouter } from 'next/router';
 import { Tab } from '@headlessui/react';
@@ -33,7 +34,7 @@ export default function Inquiry() {
   const [fileLists, setFileLists] = useState<File[]>([]);
   const [fileSize, setFileSize] = useState<number>(0);
   const [selectedIndex, setSelectedIndex] = useState<number>(0);
-  const { mutate: postInquiry } = usePostInquiry(postData);
+  const { mutate: postInquiry, isLoading } = usePostInquiry(postData);
   const { data } = useGetInquiry();
 
   const router = useRouter();
@@ -90,15 +91,16 @@ export default function Inquiry() {
     }
     console.log(image);
     setPostData(() => formData);
-    clearForm();
-    setSelectedIndex(1);
   };
-
   useEffect(() => {
     if (postData) {
       postInquiry();
+      clearForm();
+      setSelectedIndex(1);
     }
   }, [postData]);
+
+  if (isLoading) return <Loader />;
 
   return (
     <Layout>


### PR DESCRIPTION
## 🧑‍💻 PR 내용

답변이 완료됐을때의 문의 페이지 디자인이 제대로 구현되지 못한 점을 수정했습니다.

추가적으로 문의 등록 후 낙관적 업데이트를 구현하지 못한부분을 제거했습니다.
이 부분을 제거하니 문의 등록후 문의 내역으로 이동시 처음에 "1대1 문의 내역이 없습니다" 라고 뜨는 부분이 사라졌습니다.

## 📸 스크린샷
[수정 전]

![image](https://user-images.githubusercontent.com/79186378/218932477-de1e9d43-e3bd-4557-843e-eed83adb977c.png)

![녹화_2023_02_15_14_12_39_967](https://user-images.githubusercontent.com/79186378/218938850-a185a66e-574d-406e-a6dc-ed107258d007.gif)



[수정 후]
![image](https://user-images.githubusercontent.com/79186378/218932218-7efae3e7-e606-46b4-a6b0-8cba8fe1c12c.png)


![녹화_2023_02_15_14_13_07_782](https://user-images.githubusercontent.com/79186378/218938868-b75f0d83-2df2-4cdf-89a7-a679f13a6e0e.gif)

