### PR TITLE
응찰페이지 작품사진 보여주기 및 내작품인경우 응찰 버튼 비활성화 

### DIFF
--- a/src/@types/auction.d.ts
+++ b/src/@types/auction.d.ts
@@ -68,6 +68,7 @@ interface BiddingHistory {
     genre: string;
     beginPrice: number;
     topPrice: number;
+    image: string;
   };
   auction: {
     id: number;

--- a/src/pages/auction/bidding.tsx
+++ b/src/pages/auction/bidding.tsx
@@ -23,6 +23,7 @@ export default function Bidding() {
   const router = useRouter();
   const artWorkId = Number(router.query.id);
   const { data } = useGetBiddingHistory(artWorkId);
+
   const { artWork, auction, biddingList, totalBiddingCount } = data || {};
   const { mutate } = usePutBiddng(+artWorkId!);
   const { data: userInfo } = useGetProfile();
@@ -31,7 +32,7 @@ export default function Bidding() {
   );
   const remaind = +days + +hours + +minutes + +seconds;
   const [isBlurred, setIsBlurred] = useState(true);
-  const isMine = artWork?.id === userInfo?.id;
+  const isMine = artWork?.artistName === userInfo?.nickname;
 
   const {
     register,

--- a/src/pages/auction/bidding.tsx
+++ b/src/pages/auction/bidding.tsx
@@ -80,12 +80,14 @@ export default function Bidding() {
           <div className="textd-16 font-medium">작품정보</div>
           <div className="mt-3 flex items-center">
             <div className="relative h-[97px] w-[85px] overflow-hidden rounded-[4px]">
-              <Image
-                alt="image"
-                src="/svg/example/example_artwork_1.svg"
-                fill
-                className="object-cover"
-              />
+              {artWork?.image && (
+                <Image
+                  alt="image"
+                  src={artWork?.image}
+                  fill
+                  className="object-cover"
+                />
+              )}
             </div>
             <div className="ml-3 h-fit flex-col">
               <p className="text-15 font-semibold leading-5">


### PR DESCRIPTION
## 🧑‍💻 PR 내용
응찰페이지에서 작품사진을 보여줍니다. 
내 작품인경우 응찰이 불가능 하도록 버튼을 비활성화 합니다. (내 작품인지 확인할때 기존 id 값으로 비교시 서로 다른 id여서 artistName과 nickName을 비교하도록 했습니다.)

## 📸 스크린샷

<img width="320" alt="image" src="https://user-images.githubusercontent.com/92621861/218953395-4f3065f6-43af-4f05-8780-e68cb1f2c03c.png">