### PR TITLE
프로필 사진 통합

### DIFF
--- a/src/components/exhibition/Modal.tsx
+++ b/src/components/exhibition/Modal.tsx
@@ -58,7 +58,7 @@ export default function Modal({
 
   const handleRightButton = () => {
     router.push({
-      pathname: '/auction/view',
+      pathname: '/profile/detail',
       query: { id: artistId },
     });
   };

--- a/src/pages/auction/view.tsx
+++ b/src/pages/auction/view.tsx
@@ -235,25 +235,35 @@ export default function View() {
           <div className="mt-8 border-y border-y-[#EDEDED] py-8">
             <div className="flex w-[74px] flex-col items-center justify-center">
               <p className="w-full text-center font-medium">작가프로필</p>
-              <div className="relative my-2 flex aspect-square w-[4rem] items-center justify-center rounded-full border border-[#999999]">
-                <Image
-                  src={
-                    artist?.artistImage || '/svg/icons/profile/icon_avatar.svg'
-                  }
-                  alt="profile"
-                  className={`cursor-pointer object-cover ${
-                    !!artist?.artistImage && 'rounded-full'
-                  }`}
-                  onClick={() => {
-                    router.push({
-                      pathname: '/profile/detail',
-                      query: { id: artist?.id },
-                    });
-                  }}
-                  fill={!!artist?.artistImage}
-                  width={!artist?.artistImage ? 40 : 0}
-                  height={!artist?.artistImage ? 40 : 0}
-                />
+              <div className="relative my-2 flex aspect-square w-[4rem] cursor-pointer items-center justify-center overflow-hidden rounded-full border  border-[#999999]">
+                {artist?.artistImage ? (
+                  <Image
+                    src={artist?.artistImage}
+                    alt="profile"
+                    priority
+                    fill
+                    className="object-cover"
+                    onClick={() => {
+                      router.push({
+                        pathname: '/profile/detail',
+                        query: { id: artist?.id },
+                      });
+                    }}
+                  />
+                ) : (
+                  <Image
+                    src="/svg/icons/profile/icon_avatar.svg"
+                    alt="user"
+                    width={40}
+                    height={40}
+                    onClick={() => {
+                      router.push({
+                        pathname: '/profile/detail',
+                        query: { id: artist?.id },
+                      });
+                    }}
+                  />
+                )}
               </div>
               <div className="w-fulltext-center ">{artist?.artistName}</div>
             </div>

--- a/src/pages/profile/detail.tsx
+++ b/src/pages/profile/detail.tsx
@@ -20,7 +20,7 @@ w-full flex items-center mt-5 mb-8
 `;
 
 const PickDetailProfile = tw.div<defaultProps>`
-w-[60px] mr-[10px] aspect-square flex  justify-center items-center rounded-full border-[1px] border-[#999999]
+w-[60px] mr-[10px] aspect-square flex justify-center items-center rounded-full border-[1px] border-[#999999] overflow-hidden relative
 `;
 
 export default function PickDetail() {
@@ -47,12 +47,22 @@ export default function PickDetail() {
       <Navigate isRightButton={false} message="작가 프로필" />
       <PickDetailContainer>
         <PickDetailProfile>
-          <Image
-            src={member?.image || '/svg/icons/icon_user_gray.svg'}
-            alt="avatar"
-            width={34}
-            height={34}
-          />
+          {member?.image ? (
+            <Image
+              src={member?.image}
+              alt="profile"
+              priority
+              fill
+              className="object-cover"
+            />
+          ) : (
+            <Image
+              src="/svg/icons/profile/icon_avatar.svg"
+              alt="user"
+              width={40}
+              height={40}
+            />
+          )}
         </PickDetailProfile>
         <div className="flex h-10 flex-col">
           <span className="text-18 font-semibold">{member?.nickname}</span>

--- a/src/pages/profile/index.tsx
+++ b/src/pages/profile/index.tsx
@@ -123,7 +123,7 @@ export default function Profile() {
                 />
               ) : (
                 <Image
-                  src="/svg/icons/icon_user_gray.svg"
+                  src="/svg/icons/profile/icon_avatar.svg"
                   alt="user"
                   width={100}
                   height={100}


### PR DESCRIPTION
## 🧑‍💻 PR 내용

auction/view 페이지 내에서 작가의 프로필 사진이 있는 경우 흐릿하게 보이는 현상을 수정했습니다.
exhibition/view 페이지 내에서 모달의 작가 프로필을 클릭했을 때 경로가 auction/view로 되어있어서 이부분도 작가의 프로필로 이동할 수 있도록 /profile/view로 경로 수정했습니다.
작가 프로필 페이지에서도 동일하게 작가 프로필 사진 유무에 따라 흐릿하게 보이는 현상을 수정했습니다.

피그마 내에서는 프로필 페이지에서의 아바타가 회색으로 채워져있지 않지만, 프로필 페이지를 제외하고 경매 페이지, 작가 프로필 페이지등 아바타가 나타나는 페이지에서는 모두 회색으로 채워져있는 아바타를 사용하고 있습니다.
이 부분 통일을 위해 추가적으로 프로필 페이지의 회색으로 채워져있는 아바타로 교체했습니다. 

## 📸 스크린샷

**[변경 전]**

![image](https://user-images.githubusercontent.com/79186378/219053962-936d6e88-9083-4167-ab3d-055e74da832e.png)
![image](https://user-images.githubusercontent.com/79186378/219054179-819a98e4-7360-4fad-bcda-708fb7246da3.png)
![image](https://user-images.githubusercontent.com/79186378/219054838-5db01afc-76d8-42b3-9610-6c3c79a9b6cd.png)

**[변경 후]**
![image](https://user-images.githubusercontent.com/79186378/219053914-97cda77f-e5c7-4765-96fb-31d9a92acde9.png)
![image](https://user-images.githubusercontent.com/79186378/219054196-2aa11ce2-6280-459a-b548-54998c590158.png)
![image](https://user-images.githubusercontent.com/79186378/219054844-c3ebdb89-f10d-4d96-9d4c-888f51681e4b.png)
