### PR TITLE
작품 등록시 필드 필수값으로 지정 및 작품보증서 사진 오류 해결

### DIFF
--- a/src/components/auction/Guarantee.tsx
+++ b/src/components/auction/Guarantee.tsx
@@ -1,0 +1,93 @@
+import { today } from '@utils/today';
+import Image from 'next/image';
+
+interface GuaranteeProps {
+  mainImage: string;
+  nickname: string;
+  title: string;
+  productionYear: number;
+  width: number;
+  length: number;
+  height: number;
+  genre: string;
+  guaranteeImage: string;
+}
+
+export default function Guarantee({
+  mainImage,
+  nickname,
+  title,
+  productionYear,
+  width,
+  length,
+  height,
+  genre,
+  guaranteeImage,
+}: GuaranteeProps) {
+  return (
+    <article className="relative h-[457px] w-full">
+      <div className="m-auto  min-w-[327px] flex-col items-center justify-center py-9">
+        <div className="text-center text-16 font-semibold tracking-[0.3em]">
+          작 품 보 증 서
+        </div>
+        <p className="text-center text-[8px] font-light tracking-[-0.05em] text-[#A5A5A5]">
+          CERTIFICATE OF AUTHENTICITY
+        </p>
+        <div className="relative mx-auto mt-7 h-[74px] w-[116px]">
+          <Image src={mainImage} fill className="object-cover" alt="artwork" />
+        </div>
+        <div className="mt-3 flex justify-center text-11 leading-5">
+          <div className="flex-col font-semibold">
+            <p>작가</p>
+            <p>제목</p>
+            <p>제작년도</p>
+            <p>작품크기</p>
+            <p>제작기법</p>
+          </div>
+          <div className="ml-12 flex-col">
+            <p>{nickname}</p>
+            <p>{title}</p>
+            <p>{productionYear}</p>
+            <p>
+              {width}x${length}
+              x${height}cm
+            </p>
+            <p>{genre}</p>
+          </div>
+        </div>
+        <div className="mt-4 flex-col">
+          <div className="flex items-center justify-center">
+            <Image src={guaranteeImage} width={50} height={50} alt="artwork" />
+          </div>
+          <div className="mt-2 flex-col items-center justify-center">
+            <div className="mx-auto w-[70px] border-t border-t-black pb-[3px]" />
+            <div className="text-center text-[8px]  text-[#A5A5A5]">
+              Artist Signature
+            </div>
+          </div>
+        </div>
+        <ul className="mt-3 w-full list-none text-center text-[8px]">
+          <li className="w-full  text-black  before:mr-2  before:content-['\2022']">
+            본 작품은 위에 서명한 작가의 작품임을 보증합니다.
+          </li>
+          <li className="w-full text-black  before:mr-2  before:content-['\2022']">
+            본 작품은 일체의 모작, 위작이 아님을 보증합니다.
+          </li>
+          <li className="w-full text-black  before:mr-2  before:content-['\2022']">
+            본 보증서는 작품 보증 이외 환불, 교환 등의 목적으로 사용이
+            불가합니다.
+          </li>
+        </ul>
+        <p className="my-3 text-center text-[8px]">{today()}</p>
+        <div className="flex items-center justify-center text-brand">
+          <Image
+            src="/svg/post/logo_small.svg"
+            width={60}
+            height={10}
+            alt="logo"
+          />
+        </div>
+      </div>
+    </article>
+  );
+}

--- a/src/hooks/mutations/usePostArtwork.ts
+++ b/src/hooks/mutations/usePostArtwork.ts
@@ -3,7 +3,7 @@ import artworkApi from '@apis/artwork/artworkApi';
 
 import { useMutation } from 'react-query';
 
-const usePostArtwork = (setIsErrorModal) => {
+const usePostArtwork = () => {
   const router = useRouter();
   return useMutation(
     'usePostArtwork',
@@ -15,9 +15,6 @@ const usePostArtwork = (setIsErrorModal) => {
           pathname: '/auction/view',
           query: { id: data.artWork.id },
         });
-      },
-      onError: () => {
-        setIsErrorModal(true);
       },
     },
   );

--- a/src/pages/auction/view.tsx
+++ b/src/pages/auction/view.tsx
@@ -301,7 +301,7 @@ export default function View() {
 
           <article className="relative h-[457px] w-full">
             {artWork?.images && artWork.guaranteeImage && (
-              <div className="m-auto hidden min-w-[327px] flex-col items-center justify-center py-9">
+              <div className="m-auto  min-w-[327px] flex-col items-center justify-center py-9">
                 <div className="text-center text-16 font-semibold tracking-[0.3em]">
                   작 품 보 증 서
                 </div>

--- a/src/pages/auction/view.tsx
+++ b/src/pages/auction/view.tsx
@@ -10,6 +10,8 @@ import useDeletePrefer from '@hooks/mutations/useDeletePrefer';
 import { useCountDown } from '@hooks/useCountDown';
 import useGetProfile from '@hooks/queries/useGetProfile';
 import KeywordBox from '@components/common/KeywordBox';
+import { today } from '@utils/today';
+import { toPng } from 'html-to-image';
 
 export default function View() {
   const router = useRouter();
@@ -72,7 +74,7 @@ export default function View() {
     <>
       <Layout>
         <div
-          className={`fixed inset-x-0 top-4 z-50 mx-auto flex h-16 w-full max-w-[420px] items-center justify-between px-5 ${
+          className={`fixed inset-x-0 top-0 z-50 mx-auto flex h-16 w-full max-w-[420px] items-center justify-between px-5 ${
             isCardOver && 'bg-white'
           }`}
         >
@@ -298,14 +300,79 @@ export default function View() {
           </article>
 
           <article className="relative h-[457px] w-full">
-            {artWork?.guaranteeImage && (
-              <Image
-                alt="guarantee"
-                src={artWork?.guaranteeImage}
-                fill
-                className="object-contain"
-                priority
-              />
+            {artWork?.images && artWork.guaranteeImage && (
+              <div className="m-auto hidden min-w-[327px] flex-col items-center justify-center py-9">
+                <div className="text-center text-16 font-semibold tracking-[0.3em]">
+                  작 품 보 증 서
+                </div>
+                <p className="text-center text-[8px] font-light tracking-[-0.05em] text-[#A5A5A5]">
+                  CERTIFICATE OF AUTHENTICITY
+                </p>
+                <div className="relative mx-auto mt-7 h-[74px] w-[116px]">
+                  <Image
+                    src={artWork?.images[0]}
+                    fill
+                    className="object-cover"
+                    alt="artwork"
+                  />
+                </div>
+                <div className="mt-3 flex justify-center text-11 leading-5">
+                  <div className="flex-col font-semibold">
+                    <p>작가</p>
+                    <p>제목</p>
+                    <p>제작년도</p>
+                    <p>작품크기</p>
+                    <p>제작기법</p>
+                  </div>
+                  <div className="ml-12 flex-col">
+                    <p>{userInfo?.nickname}</p>
+                    <p>{artWork.title}</p>
+                    <p>{artWork.productionYear}</p>
+                    <p>
+                      {artWork.artWorkSize.width}x${artWork.artWorkSize.length}
+                      x${artWork.artWorkSize.height}cm
+                    </p>
+                    <p>{artWork.genre}</p>
+                  </div>
+                </div>
+                <div className="mt-4 flex-col">
+                  <div className="flex items-center justify-center">
+                    <Image
+                      src={artWork.guaranteeImage}
+                      width={50}
+                      height={50}
+                      alt="artwork"
+                    />
+                  </div>
+                  <div className="mt-2 flex-col items-center justify-center">
+                    <div className="mx-auto w-[70px] border-t border-t-black pb-[3px]" />
+                    <div className="text-center text-[8px]  text-[#A5A5A5]">
+                      Artist Signature
+                    </div>
+                  </div>
+                </div>
+                <ul className="mt-3 w-full list-none text-center text-[8px]">
+                  <li className="w-full  text-black  before:mr-2  before:content-['\2022']">
+                    본 작품은 위에 서명한 작가의 작품임을 보증합니다.
+                  </li>
+                  <li className="w-full text-black  before:mr-2  before:content-['\2022']">
+                    본 작품은 일체의 모작, 위작이 아님을 보증합니다.
+                  </li>
+                  <li className="w-full text-black  before:mr-2  before:content-['\2022']">
+                    본 보증서는 작품 보증 이외 환불, 교환 등의 목적으로 사용이
+                    불가합니다.
+                  </li>
+                </ul>
+                <p className="my-3 text-center text-[8px]">{today()}</p>
+                <div className="flex items-center justify-center text-brand">
+                  <Image
+                    src="/svg/post/logo_small.svg"
+                    width={60}
+                    height={10}
+                    alt="logo"
+                  />
+                </div>
+              </div>
             )}
           </article>
           <div className="h-[7rem]" />

--- a/src/pages/auction/view.tsx
+++ b/src/pages/auction/view.tsx
@@ -10,8 +10,7 @@ import useDeletePrefer from '@hooks/mutations/useDeletePrefer';
 import { useCountDown } from '@hooks/useCountDown';
 import useGetProfile from '@hooks/queries/useGetProfile';
 import KeywordBox from '@components/common/KeywordBox';
-import { today } from '@utils/today';
-import { toPng } from 'html-to-image';
+import Guarantee from '@components/auction/Guarantee';
 
 export default function View() {
   const router = useRouter();
@@ -298,83 +297,19 @@ export default function View() {
               </div>
             ))}
           </article>
-
-          <article className="relative h-[457px] w-full">
-            {artWork?.images && artWork.guaranteeImage && (
-              <div className="m-auto  min-w-[327px] flex-col items-center justify-center py-9">
-                <div className="text-center text-16 font-semibold tracking-[0.3em]">
-                  작 품 보 증 서
-                </div>
-                <p className="text-center text-[8px] font-light tracking-[-0.05em] text-[#A5A5A5]">
-                  CERTIFICATE OF AUTHENTICITY
-                </p>
-                <div className="relative mx-auto mt-7 h-[74px] w-[116px]">
-                  <Image
-                    src={artWork?.images[0]}
-                    fill
-                    className="object-cover"
-                    alt="artwork"
-                  />
-                </div>
-                <div className="mt-3 flex justify-center text-11 leading-5">
-                  <div className="flex-col font-semibold">
-                    <p>작가</p>
-                    <p>제목</p>
-                    <p>제작년도</p>
-                    <p>작품크기</p>
-                    <p>제작기법</p>
-                  </div>
-                  <div className="ml-12 flex-col">
-                    <p>{userInfo?.nickname}</p>
-                    <p>{artWork.title}</p>
-                    <p>{artWork.productionYear}</p>
-                    <p>
-                      {artWork.artWorkSize.width}x${artWork.artWorkSize.length}
-                      x${artWork.artWorkSize.height}cm
-                    </p>
-                    <p>{artWork.genre}</p>
-                  </div>
-                </div>
-                <div className="mt-4 flex-col">
-                  <div className="flex items-center justify-center">
-                    <Image
-                      src={artWork.guaranteeImage}
-                      width={50}
-                      height={50}
-                      alt="artwork"
-                    />
-                  </div>
-                  <div className="mt-2 flex-col items-center justify-center">
-                    <div className="mx-auto w-[70px] border-t border-t-black pb-[3px]" />
-                    <div className="text-center text-[8px]  text-[#A5A5A5]">
-                      Artist Signature
-                    </div>
-                  </div>
-                </div>
-                <ul className="mt-3 w-full list-none text-center text-[8px]">
-                  <li className="w-full  text-black  before:mr-2  before:content-['\2022']">
-                    본 작품은 위에 서명한 작가의 작품임을 보증합니다.
-                  </li>
-                  <li className="w-full text-black  before:mr-2  before:content-['\2022']">
-                    본 작품은 일체의 모작, 위작이 아님을 보증합니다.
-                  </li>
-                  <li className="w-full text-black  before:mr-2  before:content-['\2022']">
-                    본 보증서는 작품 보증 이외 환불, 교환 등의 목적으로 사용이
-                    불가합니다.
-                  </li>
-                </ul>
-                <p className="my-3 text-center text-[8px]">{today()}</p>
-                <div className="flex items-center justify-center text-brand">
-                  <Image
-                    src="/svg/post/logo_small.svg"
-                    width={60}
-                    height={10}
-                    alt="logo"
-                  />
-                </div>
-              </div>
-            )}
-          </article>
+          {artWork && artist && (
+            <Guarantee
+              mainImage={artWork?.images[0]}
+              guaranteeImage={artWork?.guaranteeImage}
+              title={artWork?.title}
+              nickname={artist?.artistName}
+              productionYear={artWork?.productionYear}
+              genre={artWork?.genre}
+              width={artWork?.artWorkSize?.width}
+              length={artWork?.artWorkSize?.length}
+              height={artWork?.artWorkSize?.height}
+            />
+          )}
           <div className="h-[7rem]" />
         </section>
       </Layout>

--- a/src/pages/home/index.tsx
+++ b/src/pages/home/index.tsx
@@ -54,6 +54,7 @@ export default function Home() {
   const { data: userInfo } = useGetProfile();
   const { data: auctionList } = useGetAuction() || {};
   const { data: pastAuctionList } = useGetPastAuction() || {};
+
   return (
     <>
       <Layout>
@@ -215,7 +216,13 @@ export default function Home() {
               )}
           </Swiper>
         </PastAuction>
-        {isUser ? <div className="h-16" /> : <FloatButton />}
+        {isUser ||
+        !auctionList?.filter((auction) => auction.status === 'scheduled')
+          .length ? (
+          <div className="h-16" />
+        ) : (
+          <FloatButton />
+        )}
       </Layout>
       <Tab />
     </>

--- a/src/pages/home/post.tsx
+++ b/src/pages/home/post.tsx
@@ -136,10 +136,31 @@ export default function Post() {
       statusDescription,
     } = form;
 
+    if (fileList.length === 0) {
+      setError('image', {
+        type: 'required',
+        message: '작품 사진을 최소 한 장 이상 선택해주세요.',
+      });
+      return;
+    }
     if (keywordList.length === 0) {
       setError('keywords', {
         type: 'required',
-        message: '키워드를 입력해주세요.',
+        message: '태그를 최소 한 개 이상 선택해주세요.',
+      });
+      return;
+    }
+    if (genre === '') {
+      setError('genre', {
+        type: 'required',
+        message: '장르를 선택해주세요.',
+      });
+      return;
+    }
+    if (signature === '') {
+      setError('guaranteeImage', {
+        type: 'required',
+        message: '작가 서명을 입력해주세요.',
       });
       return;
     }
@@ -243,14 +264,12 @@ export default function Post() {
             type="file"
             id="fileImage"
             className="hidden"
-            {...register('image', {
-              required: true,
-            })}
             onChange={handleImage}
           />
         </div>
         {errors.image && (
           <ErrorMessage
+            className="mt-2"
             message={'작품 이미지를 최소 한 장 이상 등록해주세요.'}
           />
         )}
@@ -261,7 +280,13 @@ export default function Post() {
             placeholder="작품명을 입력해주세요"
             register={register('title', { required: true })}
           />
-          <button onClick={() => setIsKeywordModal(true)} className="relative">
+          <button
+            onClick={() => {
+              clearErrors('keywords');
+              setIsKeywordModal(true);
+            }}
+            className="relative"
+          >
             <div className="flex h-[38px] w-[92px] items-center rounded-[4px] border border-[#D8D8D8] pl-3 text-[13px] text-[#999999]">
               태그추가
             </div>
@@ -288,8 +313,15 @@ export default function Post() {
           label="제작연도"
           min={2010}
           placeholder="숫자만 입력해주세요. ex)2022"
-          register={register('productionYear', { required: true })}
+          register={register('productionYear', {
+            required: true,
+            min: 2010,
+            max: 2023,
+          })}
         />
+        {errors.productionYear && (
+          <ErrorMessage message="제작년도를 확인해주세요." />
+        )}
         <div>
           <div className="flex justify-between">
             <label htmlFor="description" className="text-14 leading-8">
@@ -320,7 +352,12 @@ export default function Post() {
           placeholder="사용한 재료를 입력해주세요."
           register={register('material', { required: true })}
         />
-        <div onClick={() => setIsGenreModal(true)}>
+        <div
+          onClick={() => {
+            clearErrors('genre');
+            setIsGenreModal(true);
+          }}
+        >
           <label className="text-14 leading-8">장르</label>
           <div
             className={`flex h-[52px] w-full cursor-pointer items-center rounded-[4px] border border-[#D8D8D8] pl-3 text-[13px] ${
@@ -330,6 +367,7 @@ export default function Post() {
             {genre ? genre : '선택하기'}
           </div>
         </div>
+        {errors.genre && <ErrorMessage message={errors.genre.message} />}
         <Select
           name="frame"
           setValue={setValue}
@@ -399,7 +437,10 @@ export default function Post() {
         />
         <div
           className="w-full cursor-pointer"
-          onClick={() => setIsGuaranteeModal(true)}
+          onClick={() => {
+            clearErrors('guaranteeImage');
+            setIsGuaranteeModal(true);
+          }}
         >
           <label htmlFor="statusDetail" className="text-14 leading-8">
             작품 보증서
@@ -431,6 +472,9 @@ export default function Post() {
             </div>
           )}
         </div>
+        {errors.guaranteeImage && (
+          <ErrorMessage message={errors.guaranteeImage.message} />
+        )}
         {user &&
           watch('title') &&
           watch('productionYear') &&

--- a/src/pages/home/post.tsx
+++ b/src/pages/home/post.tsx
@@ -17,7 +17,6 @@ import usePostArtwork from '@hooks/mutations/usePostArtwork';
 import Loader from '@components/common/Loader';
 import { makeBlob } from '@utils/makeBlob';
 import useGetProfile from '@hooks/queries/useGetProfile';
-import { today } from '@utils/today';
 import { dataURLtoFile } from '@utils/dataURLtoFile';
 import Guarantee from '@components/auction/Guarantee';
 

--- a/src/pages/home/post.tsx
+++ b/src/pages/home/post.tsx
@@ -19,6 +19,7 @@ import { makeBlob } from '@utils/makeBlob';
 import useGetProfile from '@hooks/queries/useGetProfile';
 import { today } from '@utils/today';
 import { dataURLtoFile } from '@utils/dataURLtoFile';
+import Guarantee from '@components/auction/Guarantee';
 
 const ARTWORK_STATUS = [
   { value: '매우 좋음' },
@@ -483,75 +484,17 @@ export default function Post() {
           watch('height') &&
           watch('genre') &&
           signature && (
-            <div
-              ref={guaranteeRef}
-              className="m-auto min-w-[327px] flex-col items-center justify-center py-9"
-            >
-              <div className="text-center text-16 font-semibold tracking-[0.3em]">
-                작 품 보 증 서
-              </div>
-              <p className="text-center text-[8px] font-light tracking-[-0.05em] text-[#A5A5A5]">
-                CERTIFICATE OF AUTHENTICITY
-              </p>
-              <div className="relative mx-auto mt-7 h-[74px] w-[116px]">
-                <Image
-                  src={makeBlob(fileList[0])}
-                  fill
-                  className="object-cover"
-                  alt="artwork"
-                />
-              </div>
-              <div className="mt-3 flex justify-center text-11 leading-5">
-                <div className="flex-col font-semibold">
-                  <p>작가</p>
-                  <p>제목</p>
-                  <p>제작년도</p>
-                  <p>작품크기</p>
-                  <p>제작기법</p>
-                </div>
-                <div className="ml-12 flex-col">
-                  <p>{user?.nickname}</p>
-                  <p>{watch('title')}</p>
-                  <p>{watch('productionYear')}</p>
-                  <p>{`${watch('width')}x${watch('length')}x${watch(
-                    'height',
-                  )}cm`}</p>
-                  <p>{watch('genre')}</p>
-                </div>
-              </div>
-              <div className="mt-4 flex-col">
-                <div className="flex items-center justify-center">
-                  <Image src={signature} width={50} height={50} alt="artwork" />
-                </div>
-                <div className="mt-2 flex-col items-center justify-center">
-                  <div className="mx-auto w-[70px] border-t border-t-black pb-[3px]" />
-                  <div className="text-center text-[8px]  text-[#A5A5A5]">
-                    Artist Signature
-                  </div>
-                </div>
-              </div>
-              <ul className="mt-3 w-full list-none text-center text-[8px]">
-                <li className="w-full  text-black  before:mr-2  before:content-['\2022']">
-                  본 작품은 위에 서명한 작가의 작품임을 보증합니다.
-                </li>
-                <li className="w-full text-black  before:mr-2  before:content-['\2022']">
-                  본 작품은 일체의 모작, 위작이 아님을 보증합니다.
-                </li>
-                <li className="w-full text-black  before:mr-2  before:content-['\2022']">
-                  본 보증서는 작품 보증 이외 환불, 교환 등의 목적으로 사용이
-                  불가합니다.
-                </li>
-              </ul>
-              <p className="my-3 text-center text-[8px]">{today()}</p>
-              <div className="flex items-center justify-center text-brand">
-                <Image
-                  src="/svg/post/logo_small.svg"
-                  width={60}
-                  height={10}
-                  alt="logo"
-                />
-              </div>
-            </div>
+            <Guarantee
+              nickname={user.nickname}
+              title={watch('title')}
+              productionYear={watch('productionYear')}
+              width={watch('width')}
+              length={watch('length')}
+              height={watch('height')}
+              genre={watch('genre')}
+              guaranteeImage={signature}
+              mainImage={makeBlob(fileList[0])}
+            />
           )}
 
         <div className="relative h-[336px]">


### PR DESCRIPTION
## 🧑‍💻 PR 내용
예정된 경매가 없을 경우 홈에서 작품등록 버튼이 보이지 않도록 했습니다. 
작품 등록시 값들을 모두 추가해야만 작품등록이 가능하도록 error처리를 했습니다. 
작품보증서의 경우 기존대로 사인사진만 서버로 보내고 컴포넌트에 데이터를 넣어서 보여주는것으로 대체했습니다.  

## 📸 스크린샷

<img width="293" alt="image" src="https://user-images.githubusercontent.com/92621861/219754257-7c05c365-86ce-4804-ace7-f774184c2bfc.png">
<img width="306" alt="image" src="https://user-images.githubusercontent.com/92621861/219754532-280a8bfa-6f4c-45cf-bd7a-1805da9aad71.png">
<img width="296" alt="image" src="https://user-images.githubusercontent.com/92621861/219754681-27bc2346-48b8-4a37-9036-c78b63efdf19.png">
<img width="305" alt="image" src="https://user-images.githubusercontent.com/92621861/219755066-49a8cd23-6178-4f9a-b9f7-23c61226b0ed.png">
