### PR TITLE
작품 삭제 및 수정 페이지 구현

### DIFF
--- a/src/apis/artwork/artworkApi.ts
+++ b/src/apis/artwork/artworkApi.ts
@@ -10,6 +10,15 @@ export class ArtworkApi {
     return data;
   }
 
+  async patchArtwork(id: number, body: FormData): Promise<any> {
+    const { data } = await instance.patch(`/art-works/edit/${id}`, body, {
+      headers: {
+        'Content-Type': 'multipart/form-data',
+      },
+    });
+    return data;
+  }
+
   async deleteArtwork(artworkId: number) {
     await instance.delete(`/art-works/${artworkId}`);
   }

--- a/src/apis/artwork/artworkApi.ts
+++ b/src/apis/artwork/artworkApi.ts
@@ -9,6 +9,16 @@ export class ArtworkApi {
     });
     return data;
   }
+
+  async deleteArtwork(artworkId: number) {
+    await instance.delete(`/art-works/${artworkId}`);
+  }
+
+  async getEditForm(artworkId: number) {
+    const { data } = await instance.get(`/art-works/edit/${artworkId}`);
+    return data;
+  }
+
   async getDetail(artWorkId: number): Promise<ArtworkDetail> {
     const { data } = await instance.get(`art-works/${artWorkId}`);
     return data;

--- a/src/components/admin/PastAuctionList.tsx
+++ b/src/components/admin/PastAuctionList.tsx
@@ -44,8 +44,8 @@ export default function PastAuctionList({
               auctionDateList.map((it, idx) => (
                 <tr key={idx}>
                   <td>{it.turn}</td>
-                  <td>{it.startDate.format('YYYY.MM.DD.hh:mm')}</td>
-                  <td>{it.endDate.format('YYYY.MM.DD.hh:mm')}</td>
+                  <td>{it.startDate.format('MM/DD H시m분')}</td>
+                  <td>{it.endDate.format('MM/DD H시m분')}</td>
                 </tr>
               ))}
           </tbody>

--- a/src/components/common/Input.tsx
+++ b/src/components/common/Input.tsx
@@ -1,5 +1,5 @@
-import React from 'react'
-import tw from 'tailwind-styled-components'
+import React from 'react';
+import tw from 'tailwind-styled-components';
 
 import type { UseFormRegisterReturn } from 'react-hook-form';
 interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
@@ -29,6 +29,11 @@ w-full h-[52px] placeholder-[#999999] text-[13px] rounded-[4px] ${(p) =>
   p.$error ? 'border-[#FF3120]' : 'border-[#D8D8D8]'} ${(p) =>
   p.$unit && 'pr-10'} appearance-none
   `;
+const TextAreaTag = tw.textarea<InputProps>`
+w-full h-[52px] placeholder-[#999999] text-[13px] rounded-[4px] ${(p) =>
+  p.$error ? 'border-[#FF3120]' : 'border-[#D8D8D8]'} ${(p) =>
+  p.$unit && 'pr-10'} appearance-none flex items-center min-h-[100px]
+  `;
 export default function Input({
   type = 'text',
   label,
@@ -37,6 +42,21 @@ export default function Input({
   unit,
   ...rest
 }: InputProps) {
+  if (type === 'textarea') {
+    return (
+      <InputBox className="my-1">
+        <Label>{label}</Label>
+        <TextAreaTag
+          type={type}
+          placeholder={placeholder}
+          $unit={unit}
+          {...register}
+          {...rest}
+        />
+        {unit && <span className="absolute right-4 bottom-4">{unit}</span>}
+      </InputBox>
+    );
+  }
   return (
     <InputBox className="my-1">
       <Label>{label}</Label>

--- a/src/components/common/Modal.tsx
+++ b/src/components/common/Modal.tsx
@@ -14,10 +14,10 @@ interface DefaultProps {
   [key: string]: any;
 }
 
-const ModalTag = tw.div<DefaultProps>`fixed inset-x-0 inset-y-0 z-10`;
+const ModalTag = tw.div<DefaultProps>`fixed inset-x-0 inset-y-0 z-20`;
 
 const ModalBackground = tw.div`
-  absolute inset-0 bg-[#767676] opacity-80 backdrop-blur-3xl z-10
+  absolute inset-0 bg-[#767676] opacity-80 backdrop-blur-3xl z-20
 `;
 const ModalInner = tw.div<DefaultProps>`
   z-20 w-[327px] h-[156px] absolute inset-0 m-auto

--- a/src/components/exhibition/GenreModal.tsx
+++ b/src/components/exhibition/GenreModal.tsx
@@ -7,6 +7,7 @@ interface GenreModalProps {
   onCloseModal: () => void;
   genre: string[];
   setGenre: Dispatch<SetStateAction<string[]>>;
+  isEmpty?: boolean;
   [key: string]: any;
 }
 
@@ -36,6 +37,7 @@ export default function GenreModal({
   onCloseModal,
   genre,
   setGenre,
+  isEmpty,
 }: GenreModalProps) {
   const onGenreClick = (name: string) => {
     const genreSelectedArr = [...genre];
@@ -71,6 +73,11 @@ export default function GenreModal({
           </div>
         ))}
       </div>
+      {isEmpty && (
+        <div className="mt-52 rounded-[8px] bg-[#191919] py-4 px-3 text-12 text-white">
+          관련 작품이 없어요.
+        </div>
+      )}
     </Layout>
   );
 }

--- a/src/components/exhibition/Modal.tsx
+++ b/src/components/exhibition/Modal.tsx
@@ -18,12 +18,12 @@ interface DefaultProps {
 }
 
 const ModalInner = tw.div<DefaultProps>`
-w-full h-auto m-auto rounded-[8px] backdrop-blur-[25.5px] p-5 transition  ${(
+w-full h-auto m-auto rounded-[8px] backdrop-blur-[25.5px] p-5 transition min-h-[220px] ${(
   p,
 ) =>
   p.$open
-    ? 'bg-gradient-to-r from-[#FFFFFF]/[.16] to-[#FFFFFF]/[.46] translate-y-[-420px]'
-    : 'bg-gradient-to-b from-[#FFFFFF]/[.16] to-[#FFFFFF]/[.46]'}
+    ? 'shadow-black shadow-md drop-shadow-2xl bg-white translate-y-[-420px] bg-gradient-to-b from-[#f5f1f1] via-[#e0dddd] to-[#f5f1f1]'
+    : 'shadow-black bg-gradient-to-b from-[#FFFFFF] to-[#d1d1d1] '}
 `;
 const ModalHeader = tw.div<DefaultProps>`
 text-[#424242] text-20 flex justify-between font-bold `;
@@ -78,7 +78,7 @@ export default function Modal({
         </ModalHeader>
         <EducationDiv>{education}</EducationDiv>
         <DescriptionDiv>{description}</DescriptionDiv>
-        <div className="flex w-full justify-evenly pt-4">
+        <div className="absolute inset-x-0 bottom-5 m-auto flex w-full justify-evenly pt-4">
           <ModalButton onClick={handleLeftButton}>작품 더보기</ModalButton>
           <ModalButton onClick={handleRightButton}>작가 프로필</ModalButton>
         </div>

--- a/src/components/home/Calendar.tsx
+++ b/src/components/home/Calendar.tsx
@@ -27,7 +27,11 @@ export default React.memo(function Calendar({
     if (!!auctionList || !!pastAuctionList) {
       setAuctionDateList(
         [...auctionList, ...pastAuctionList].map((it) => {
-          return { startDate: it.startDate, endDate: it.endDate };
+          return {
+            startDate: it.startDate,
+            endDate: it.endDate,
+            status: it.status,
+          };
         }),
       );
     }
@@ -58,9 +62,9 @@ export default React.memo(function Calendar({
                   current.isSameOrAfter(it.startDate, 'days') &&
                   current.isSameOrBefore(it.endDate, 'days')
                 ) {
-                  if (moment().isAfter(it.endDate, 'days')) {
+                  if (moment().isAfter(it.endDate)) {
                     status = 'done';
-                  } else if (moment().isBefore(it.startDate, 'days')) {
+                  } else if (moment().isBefore(it.startDate)) {
                     status = 'expected';
                   } else {
                     status = 'proceeding';

--- a/src/components/home/ScheduleItem.tsx
+++ b/src/components/home/ScheduleItem.tsx
@@ -37,8 +37,17 @@ export default React.memo(function ScheduleItem({
   auctionItem,
 }: ScheduleItemForm) {
   const router = useRouter();
-  const startDate: string = auctionItem?.startDate.format('YYYY.MM.DD');
-  const endDate: string = auctionItem?.endDate.format('YYYY.MM.DD');
+
+  let startDate: string = '';
+  let endDate: string = '';
+
+  if (auctionItem.status === 'terminated') {
+    startDate = auctionItem?.startDate.format('MM.DD');
+    endDate = auctionItem?.endDate.format('MM.DD');
+  } else {
+    startDate = auctionItem?.startDate.format('MM.DD hh시 mm분');
+    endDate = auctionItem?.endDate.format('MM.DD hh시 mm분');
+  }
 
   return (
     <div className="mt-5 flex justify-between ">

--- a/src/components/inquiry/FileItem.tsx
+++ b/src/components/inquiry/FileItem.tsx
@@ -5,7 +5,7 @@ import { makeBlob } from '@utils/makeBlob';
 interface FileItemForm {
   file: any;
   key: string;
-  idx: number;
+  idx?: number;
   handler: (name: string, size: number) => void;
 }
 

--- a/src/components/inquiry/FileItem.tsx
+++ b/src/components/inquiry/FileItem.tsx
@@ -1,19 +1,20 @@
-import Image from 'next/image'
-import React from 'react'
-import { makeBlob } from '@utils/makeBlob'
+import Image from 'next/image';
+import React from 'react';
+import { makeBlob } from '@utils/makeBlob';
 
 interface FileItemForm {
   file: any;
   key: string;
+  idx: number;
   handler: (name: string, size: number) => void;
 }
 
-export default function FileItem({ file, handler }: FileItemForm) {
+export default function FileItem({ file, handler, idx }: FileItemForm) {
   return (
-    <div className="w-[60px] h-[60px] border-[1px] border-[#DBDBDB] rounded ml-3 relative mb-2">
+    <div className="relative ml-3 mb-2 h-[60px] w-[60px] rounded border-[1px] border-[#DBDBDB]">
       <div
-        onClick={() => handler(file.name, file.size)}
-        className="w-[14px] h-[14px] bg-[#999999] rounded-full flex justify-center items-center absolute right-[-5px] top-[-5px] cursor-pointer"
+        onClick={() => handler(file.name || file.idx, file.size)}
+        className="absolute right-[-5px] top-[-5px] flex h-[14px] w-[14px] cursor-pointer items-center justify-center rounded-full bg-[#999999]"
       >
         <Image
           src="/svg/icons/icon_close_white.svg"
@@ -23,11 +24,11 @@ export default function FileItem({ file, handler }: FileItemForm) {
         />
       </div>
       <Image
-        src={makeBlob(file)}
-        alt={file.name}
+        src={file.hasOwnProperty('url') ? file.url : makeBlob(file)}
+        alt={file.name || idx}
         width={20}
         height={20}
-        className="w-full h-full"
+        className="h-full w-full"
       />
     </div>
   );

--- a/src/components/profile/selling/SellingItem.tsx
+++ b/src/components/profile/selling/SellingItem.tsx
@@ -5,7 +5,7 @@ import tw from 'tailwind-styled-components';
 interface SellingItemProps {
   sellingItem: MyArtwork;
   [key: string]: any;
-  handleOption?: () => void;
+  handleOption?: (e) => void;
 }
 
 const SellingItemTag = tw.section<SellingItemProps>`
@@ -48,6 +48,7 @@ export default function SellingItem({
           height="18"
           className="absolute right-0 top-0 cursor-pointer"
           onClick={handleOption}
+          id={sellingItem.id + ''}
         />
       </SellingItemTag>
     );

--- a/src/components/profile/selling/SellingItem.tsx
+++ b/src/components/profile/selling/SellingItem.tsx
@@ -23,7 +23,10 @@ export default function SellingItem({
       <SellingItemTag
         {...rest}
         onClick={() => {
-          router.push(`/auction/view?id=${sellingItem?.id}`);
+          router.push({
+            pathname: '/auction/view',
+            query: { id: sellingItem.id },
+          });
         }}
       >
         <article className="relative h-[100px] w-[82px] overflow-hidden rounded">
@@ -55,7 +58,15 @@ export default function SellingItem({
 
   if (sellingItem.auctionStatus === 'processing')
     return (
-      <SellingItemTag {...rest}>
+      <SellingItemTag
+        {...rest}
+        onClick={() => {
+          router.push({
+            pathname: '/auction/view',
+            query: { id: sellingItem.id },
+          });
+        }}
+      >
         <article className="relative h-[100px] w-[82px] overflow-hidden rounded">
           <Image
             alt="example"
@@ -86,7 +97,15 @@ export default function SellingItem({
     );
   if (sellingItem.auctionStatus === 'sales_success')
     return (
-      <SellingItemTag {...rest}>
+      <SellingItemTag
+        {...rest}
+        onClick={() => {
+          router.push({
+            pathname: '/auction/view',
+            query: { id: sellingItem.id },
+          });
+        }}
+      >
         <article className="relative h-[100px] w-[82px] overflow-hidden rounded">
           <Image
             alt="example"
@@ -118,7 +137,15 @@ export default function SellingItem({
 
   if (sellingItem.auctionStatus === 'sales_failed')
     return (
-      <SellingItemTag {...rest}>
+      <SellingItemTag
+        {...rest}
+        onClick={() => {
+          router.push({
+            pathname: '/auction/view',
+            query: { id: sellingItem.id },
+          });
+        }}
+      >
         <article className="relative h-[100px] w-[82px] overflow-hidden rounded">
           <Image
             alt="example"

--- a/src/components/profile/selling/SellingModal.tsx
+++ b/src/components/profile/selling/SellingModal.tsx
@@ -39,6 +39,7 @@ export default function SellingModal({
       router.push({ pathname: '/profile/selling/edit', query: { id: thisId } });
     } else {
       artworkApi.deleteArtwork(thisId);
+      router.replace('/profile/selling');
     }
   };
 

--- a/src/components/profile/selling/SellingModal.tsx
+++ b/src/components/profile/selling/SellingModal.tsx
@@ -14,7 +14,7 @@ interface DefaultProps {
   [key: string]: any;
 }
 
-const ModalTag = tw.div<DefaultProps>`fixed inset-x-0 inset-y-0 z-9`;
+const ModalTag = tw.div<DefaultProps>`fixed inset-x-0 inset-y-0 z-10`;
 
 const MainModalBackground = tw.div`
   fixed inset-0 bg-[#767676] opacity-60 backdrop-blur-3xl z-9

--- a/src/components/profile/selling/SellingModal.tsx
+++ b/src/components/profile/selling/SellingModal.tsx
@@ -1,0 +1,82 @@
+import artworkApi from '@apis/artwork/artworkApi';
+import Modal from '@components/common/Modal';
+import { useState } from 'react';
+import tw from 'tailwind-styled-components';
+import { useRouter } from 'next/router';
+
+interface ModalProps {
+  onCloseModal: () => void;
+  thisId: number;
+  [key: string]: any;
+}
+
+interface DefaultProps {
+  [key: string]: any;
+}
+
+const ModalTag = tw.div<DefaultProps>`fixed inset-x-0 inset-y-0 z-9`;
+
+const MainModalBackground = tw.div`
+  fixed inset-0 bg-[#767676] opacity-60 backdrop-blur-3xl z-9
+`;
+const MainModalInner = tw.div<DefaultProps>`
+absolute z-10 w-full h-[202px] bottom-0 bg-[#fff] flex flex-col items-center justify-around
+`;
+const SelectEdit = tw.div`text-[#3478F6] w-full  grow border-b border-[#ebdede] flex justify-center items-center`;
+const SelectDelete = tw.div`text-[#FF3120] w-full  grow border-b border-[#ebdede]  flex justify-center items-center`;
+const SelectCancel = tw.div`text-[#3478F6] w-full  grow  flex justify-center items-center`;
+
+export default function SellingModal({
+  onCloseModal,
+  thisId,
+  ...rest
+}: ModalProps) {
+  const [modalMessage, setModalMessage] = useState<string>('');
+  const router = useRouter();
+
+  const handleAccept = () => {
+    if (modalMessage === '수정') {
+      router.push({ pathname: '/profile/selling/edit', query: { id: thisId } });
+    } else {
+      artworkApi.deleteArtwork(thisId);
+    }
+  };
+
+  return (
+    <>
+      {!!modalMessage && (
+        <Modal
+          isModal={modalMessage !== ''}
+          isMain
+          onCloseModal={() => {
+            setModalMessage('');
+          }}
+          message="경매 중으로 넘어간 작품은 수정/삭제가 불가능 합니다."
+          denyMessage={modalMessage}
+          className="top-5"
+          onAccept={handleAccept}
+        />
+      )}
+      <ModalTag {...rest}>
+        <MainModalBackground onClick={onCloseModal} />
+        <MainModalInner>
+          <SelectEdit
+            onClick={() => {
+              setModalMessage('수정');
+            }}
+          >
+            게시글 수정
+          </SelectEdit>
+          <SelectDelete
+            onClick={() => {
+              setModalMessage('삭제');
+            }}
+          >
+            삭제
+          </SelectDelete>
+          <SelectCancel onClick={onCloseModal}>취소</SelectCancel>
+        </MainModalInner>
+      </ModalTag>
+    </>
+  );
+}

--- a/src/hooks/mutations/usePatchArtwork.ts
+++ b/src/hooks/mutations/usePatchArtwork.ts
@@ -1,0 +1,22 @@
+import { useRouter } from 'next/router';
+import artworkApi from '@apis/artwork/artworkApi';
+
+import { useMutation } from 'react-query';
+
+const usePatchArtwork = (id: number) => {
+  const router = useRouter();
+  return useMutation(
+    'usePatchArtwork',
+    (data: FormData) => artworkApi.patchArtwork(id, data),
+    {
+      useErrorBoundary: false,
+      onSuccess: (data) => {
+        router.replace({
+          pathname: '/auction/view',
+          query: { id },
+        });
+      },
+    },
+  );
+};
+export default usePatchArtwork;

--- a/src/hooks/mutations/usePatchMember.ts
+++ b/src/hooks/mutations/usePatchMember.ts
@@ -1,16 +1,13 @@
-import { useRouter } from 'next/router';
 import profileApi from '@apis/profile/profileApi';
 import { useMutation } from 'react-query';
 
 const usePatchUser = () => {
-  const router = useRouter();
   return useMutation<any, Error, FormData>('useUserMuation', (data) =>
     profileApi.patchUser(data),
   );
 };
 
 const usePatchArtist = () => {
-  const router = useRouter();
   return useMutation<any, Error, FormData>('useArtistMuation', (data) =>
     profileApi.patchArtist(data),
   );

--- a/src/hooks/queries/artwork/useGetEditForm.ts
+++ b/src/hooks/queries/artwork/useGetEditForm.ts
@@ -1,0 +1,10 @@
+import artworkApi from '@apis/artwork/artworkApi';
+import { useQuery } from 'react-query';
+
+const useGetEditForm = (id: number) => {
+  return useQuery('useGetEditForm', () => artworkApi.getEditForm(id), {
+    retry: false,
+  });
+};
+
+export default useGetEditForm;

--- a/src/hooks/queries/artwork/useGetEditForm.ts
+++ b/src/hooks/queries/artwork/useGetEditForm.ts
@@ -2,8 +2,9 @@ import artworkApi from '@apis/artwork/artworkApi';
 import { useQuery } from 'react-query';
 
 const useGetEditForm = (id: number) => {
-  return useQuery('useGetEditForm', () => artworkApi.getEditForm(id), {
+  return useQuery(['useGetEditForm', id], () => artworkApi.getEditForm(id), {
     retry: false,
+    refetchOnWindowFocus: false,
   });
 };
 

--- a/src/hooks/queries/useGetProfile.ts
+++ b/src/hooks/queries/useGetProfile.ts
@@ -1,11 +1,20 @@
 import { useQuery } from 'react-query';
 import authApi from '@apis/auth/authApi';
-
+import { useRouter } from 'next/router';
 const useGetProfile = () => {
+  const router = useRouter();
   return useQuery<Member, Error>(
     'useGetProfile',
     () => authApi.getMemberProfile(),
-    { retry: false, refetchOnWindowFocus: false },
+    {
+      retry: false,
+      refetchOnWindowFocus: false,
+      onSuccess: (data) => {
+        if (!data.telephone) {
+          router.push('/profile/edit');
+        }
+      },
+    },
   );
 };
 

--- a/src/pages/auction/view.tsx
+++ b/src/pages/auction/view.tsx
@@ -72,7 +72,7 @@ export default function View() {
     <>
       <Layout>
         <div
-          className={`fixed inset-x-0 top-4 z-50 mx-auto flex h-16 w-full max-w-[420px] items-center justify-between px-5 ${
+          className={`fixed inset-x-0 top-0 z-50 mx-auto flex h-24 w-full max-w-[420px] items-center justify-between px-5 ${
             isCardOver && 'bg-white'
           }`}
         >

--- a/src/pages/begin.tsx
+++ b/src/pages/begin.tsx
@@ -36,11 +36,7 @@ const SwiperWrapper = styled.section`
 export default function Begin() {
   const swiperRef = useRef<any>(null);
   const router = useRouter();
-  useEffect(() => {
-    if (getLocalStorage('isVisited')) {
-      router.replace('/auth/login');
-    }
-  }, []);
+
   return (
     <Layout>
       <SwiperWrapper>

--- a/src/pages/exhibition/index.tsx
+++ b/src/pages/exhibition/index.tsx
@@ -2,6 +2,7 @@ import Layout from '@components/common/Layout';
 import Navigate from '@components/common/Navigate';
 import AuctionItem from '@components/exhibition/AuctionItem';
 import { useGetExhibition } from '@hooks/queries/useGetExhibition';
+import Image from 'next/image';
 
 export default function Exhibition() {
   const { data } = useGetExhibition();
@@ -10,9 +11,23 @@ export default function Exhibition() {
     <Layout>
       <Navigate message="전시회" isRightButton={false} />
       <div className="pt-8">
-        {data?.map((auction, idx) => (
-          <AuctionItem key={idx} auctionList={auction} />
-        ))}
+        {data && data.length > 0 ? (
+          data?.map((auction, idx) => (
+            <AuctionItem key={idx} auctionList={auction} />
+          ))
+        ) : (
+          <div className="mt-[100%] flex flex-col items-center justify-center">
+            <Image
+              alt="auction"
+              src="/svg/icons/Tab/icon_exhibition.svg"
+              width="54"
+              height="54"
+            />
+            <p className="mt-3 text-16 font-medium text-[#999999]">
+              아직 진행중인 전시회가 없어요
+            </p>
+          </div>
+        )}
       </div>
     </Layout>
   );

--- a/src/pages/exhibition/view.tsx
+++ b/src/pages/exhibition/view.tsx
@@ -53,15 +53,16 @@ export default function ExhibitionArts() {
     }
   };
 
-  if (isGenreModal)
+  if (isGenreModal) {
     return (
       <GenreModal
         genre={genre}
         setGenre={setGenre}
         onCloseModal={() => setIsGenreModal(false)}
+        isEmpty={artLists && artLists.length === 0}
       />
     );
-
+  }
   return (
     <Layout>
       {isExpansion ? (

--- a/src/pages/home/index.tsx
+++ b/src/pages/home/index.tsx
@@ -173,20 +173,21 @@ export default function Home() {
           )}
         </section>
         <section className="mb-12">
+          {!!auctionList &&
+            auctionList.reverse().map((auctionItem: AuctionList) => (
+              <div key={auctionItem?.id}>
+                <ScheduleItem auctionItem={auctionItem} />
+              </div>
+            ))}
           {!!pastAuctionList &&
             pastAuctionList
-              .slice(pastAuctionList.length - 5)
+              .slice(pastAuctionList.length - 3)
+              .reverse()
               .map((auctionItem: AuctionList) => (
                 <div key={auctionItem?.id}>
                   <ScheduleItem auctionItem={auctionItem} />
                 </div>
               ))}
-          {!!auctionList &&
-            auctionList.map((auctionItem: AuctionList) => (
-              <div key={auctionItem?.id}>
-                <ScheduleItem auctionItem={auctionItem} />
-              </div>
-            ))}
         </section>
         <PastAuction>
           <div className="mb-5 flex flex-col">
@@ -204,7 +205,7 @@ export default function Home() {
             className="h-[360px]"
           >
             {!!pastAuctionList &&
-              makeThreeEach(pastAuctionList)?.map(
+              makeThreeEach(pastAuctionList.reverse())?.map(
                 (auctionItem: AuctionList[], index: number) => (
                   <SwiperSlide key={'' + index}>
                     {auctionItem.map((auctionItem: AuctionList) => (

--- a/src/pages/home/post.tsx
+++ b/src/pages/home/post.tsx
@@ -91,7 +91,6 @@ export default function Post() {
   } = useForm<Artwork>({
     mode: 'onTouched',
   });
-  console.log(errors);
 
   const handleImage = (e) => {
     clearErrors('image');

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,9 +1,15 @@
 import Layout from '@components/common/Layout';
+import { getLocalStorage } from '@utils/localStorage/helper';
 import { useRouter } from 'next/router';
 
 export default function Home() {
   const router = useRouter();
 
-  router.replace('/begin');
+  if (getLocalStorage('isVisited')) {
+    router.replace('/auth/login');
+  } else {
+    router.replace('/begin');
+  }
+
   return <Layout></Layout>;
 }

--- a/src/pages/profile/detail.tsx
+++ b/src/pages/profile/detail.tsx
@@ -96,7 +96,7 @@ export default function PickDetail() {
             {!member?.description &&
               !member?.history &&
               !member?.instagram &&
-              !member?.behance && <div>기입된 정보가 없습니다.</div>}
+              !member?.behance && <div>등록된 정보가 없습니다.</div>}
             {member?.description && (
               <div className="space-y-3 text-14">
                 <p className="font-semibold">소개</p>

--- a/src/pages/profile/edit.tsx
+++ b/src/pages/profile/edit.tsx
@@ -42,8 +42,21 @@ export default function Edit() {
     setError,
     clearErrors,
     trigger,
-  } = useForm<Member>({ mode: 'onTouched' });
+  } = useForm<Member>({
+    mode: 'onTouched',
+    defaultValues: {
+      nickname: data?.nickname,
+      email: data?.email,
+      education: data?.education,
+      history: data?.history,
+      description: data?.description,
+      instagram: data?.instagram,
+      behance: data?.behance,
+    },
+  });
   const nickname = watch('nickname');
+
+  console.log(data);
 
   const [enabled, setEnabled] = useState<DuplicateCheck>({
     userId: '',
@@ -227,7 +240,6 @@ export default function Edit() {
           type="text"
           label="닉네임"
           placeholder="닉네임을 입력해 주세요."
-          defaultValue={userInfo?.nickname}
           $error={!!errors.nickname}
           register={register('nickname', {
             required: true,
@@ -255,10 +267,9 @@ export default function Edit() {
         type="text"
         label="이메일"
         disabled
-        defaultValue={userInfo?.email}
         placeholder="이메일을 입력해 주세요."
         $error={!!errors.email}
-        className="disabled text-[#999999]"
+        className=" text-[#999999]"
       />
 
       {!isUser && (
@@ -266,7 +277,6 @@ export default function Edit() {
           <Input
             type="text"
             label="학력"
-            defaultValue={userInfo?.education}
             placeholder="학교와 학위, 전공 등을 입력해 주세요."
             $error={!!errors.education}
             register={register('education')}
@@ -277,7 +287,6 @@ export default function Edit() {
           <Input
             type="textarea"
             label="이력"
-            defaultValue={userInfo?.history}
             placeholder="이력을 작성해 주세요."
             $error={!!errors.history}
             register={register('history')}
@@ -287,7 +296,6 @@ export default function Edit() {
             type="textarea"
             label="작가소개"
             placeholder="소개를 작성해 주세요."
-            defaultValue={userInfo?.description}
             $error={!!errors.description}
             register={register('description')}
           />

--- a/src/pages/profile/edit.tsx
+++ b/src/pages/profile/edit.tsx
@@ -42,21 +42,8 @@ export default function Edit() {
     setError,
     clearErrors,
     trigger,
-  } = useForm<Member>({
-    mode: 'onTouched',
-    defaultValues: {
-      nickname: data?.nickname,
-      email: data?.email,
-      education: data?.education,
-      history: data?.history,
-      description: data?.description,
-      instagram: data?.instagram,
-      behance: data?.behance,
-    },
-  });
+  } = useForm<Member>({ mode: 'onTouched' });
   const nickname = watch('nickname');
-
-  console.log(data);
 
   const [enabled, setEnabled] = useState<DuplicateCheck>({
     userId: '',
@@ -106,11 +93,17 @@ export default function Edit() {
   }, [profile]);
 
   const onSubmit = async (form: Member) => {
-    const { nickname, instagram, behance, education, history, description } =
-      form;
-    console.log(form);
-    if (!nickname) return;
-    if (!userInfo) return;
+    const {
+      nickname,
+      instagram,
+      behance,
+      education,
+      history,
+      description,
+      telephone,
+    } = form;
+    if (!nickname || !userInfo || !telephone) return;
+
     if (!isValidate.nickname && userInfo.nickname !== form.nickname) {
       setError('nickname', {
         type: 'need nickname duplicate',
@@ -123,7 +116,7 @@ export default function Edit() {
 
     formData.append('nickname', nickname);
     formData.append('email', data?.email!);
-    formData.append('telephone', data?.telephone!);
+    formData.append('telephone', telephone);
 
     if (profile && profile?.length) {
       //유저가 프로필을 변환하였다면
@@ -240,6 +233,7 @@ export default function Edit() {
           type="text"
           label="닉네임"
           placeholder="닉네임을 입력해 주세요."
+          defaultValue={userInfo?.nickname}
           $error={!!errors.nickname}
           register={register('nickname', {
             required: true,
@@ -265,11 +259,27 @@ export default function Edit() {
 
       <Input
         type="text"
+        label="휴대폰 번호"
+        placeholder="-를 제외하고 입력해주세요."
+        $error={!!errors.telephone}
+        register={register('telephone', {
+          required: true,
+          pattern: {
+            value: /^01([0|1|6|7|8|9])[0-9]{4}[0-9]{4}$/g,
+            message: '휴대폰번호를 정확히 입력해주세요.',
+          },
+        })}
+        defaultValue={data?.telephone}
+      />
+
+      <Input
+        type="text"
         label="이메일"
         disabled
+        defaultValue={userInfo?.email}
         placeholder="이메일을 입력해 주세요."
         $error={!!errors.email}
-        className=" text-[#999999]"
+        className="disabled text-[#999999]"
       />
 
       {!isUser && (
@@ -277,6 +287,7 @@ export default function Edit() {
           <Input
             type="text"
             label="학력"
+            defaultValue={userInfo?.education}
             placeholder="학교와 학위, 전공 등을 입력해 주세요."
             $error={!!errors.education}
             register={register('education')}
@@ -287,6 +298,7 @@ export default function Edit() {
           <Input
             type="textarea"
             label="이력"
+            defaultValue={userInfo?.history}
             placeholder="이력을 작성해 주세요."
             $error={!!errors.history}
             register={register('history')}
@@ -296,6 +308,7 @@ export default function Edit() {
             type="textarea"
             label="작가소개"
             placeholder="소개를 작성해 주세요."
+            defaultValue={userInfo?.description}
             $error={!!errors.description}
             register={register('description')}
           />

--- a/src/pages/profile/edit.tsx
+++ b/src/pages/profile/edit.tsx
@@ -275,7 +275,7 @@ export default function Edit() {
             <ErrorMessage message={errors.education.message} />
           )}
           <Input
-            type="text"
+            type="textarea"
             label="이력"
             defaultValue={userInfo?.history}
             placeholder="이력을 작성해 주세요."
@@ -284,7 +284,7 @@ export default function Edit() {
           />
           {errors.history && <ErrorMessage message={errors.history.message} />}
           <Input
-            type="text"
+            type="textarea"
             label="작가소개"
             placeholder="소개를 작성해 주세요."
             defaultValue={userInfo?.description}

--- a/src/pages/profile/index.tsx
+++ b/src/pages/profile/index.tsx
@@ -120,6 +120,14 @@ export default function Profile() {
                   priority
                   fill
                   className="object-cover"
+                  onClick={() => {
+                    router.push({
+                      pathname: '/profile/detail',
+                      query: {
+                        id: data?.id,
+                      },
+                    });
+                  }}
                 />
               ) : (
                 <Image

--- a/src/pages/profile/selling/edit.tsx
+++ b/src/pages/profile/selling/edit.tsx
@@ -1,0 +1,568 @@
+import ErrorMessage from '@components/common/ErrorMessage';
+import Input from '@components/common/Input';
+import Layout from '@components/common/Layout';
+import Modal from '@components/common/Modal';
+import Navigate from '@components/common/Navigate';
+import Select from '@components/common/Select';
+import GenreModal from '@components/home/post/GenreModal';
+import GuaranteeModal from '@components/home/post/GuaranteeModal';
+import KeywordModal from '@components/home/post/KeywordModal.tsx';
+import FileItem from '@components/inquiry/FileItem';
+import Image from 'next/image';
+import React, { useEffect, useRef, useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { getToken } from '@utils/localStorage/token';
+import KeywordBox from '@components/common/KeywordBox';
+import usePostArtwork from '@hooks/mutations/usePostArtwork';
+import Loader from '@components/common/Loader';
+import { makeBlob } from '@utils/makeBlob';
+import useGetProfile from '@hooks/queries/useGetProfile';
+import { today } from '@utils/today';
+import { toBlob } from 'html-to-image';
+import { useRouter } from 'next/router';
+import useGetEditForm from '@hooks/queries/artwork/useGetEditForm';
+
+const ARTWORK_STATUS = [
+  { value: '매우 좋음' },
+  { value: '좋음' },
+  { value: '보통' },
+];
+
+const IS_FRAME = [{ value: '있음' }, { value: '없음' }];
+
+const CANVAS_SIZE = [
+  '0',
+  '1',
+  '2',
+  '3',
+  '4',
+  '5',
+  '6',
+  '8',
+  '10',
+  '12',
+  '15',
+  '20',
+  '25',
+  '30',
+  '40',
+  '50',
+  '60',
+  '80',
+  '100',
+  '120',
+  '150',
+  '200',
+  '300',
+  '500',
+];
+
+export default function ArtworkEdit() {
+  const router = useRouter();
+  const artWorkId = Number(router.query.id);
+
+  const { data: user } = useGetProfile();
+  const { data: editForm } = useGetEditForm(artWorkId);
+  const [isGuaranteeModal, setIsGuaranteeModal] = useState<boolean>(false);
+  const [isKeywordModal, setIsKeywordModal] = useState<boolean>(false);
+  const [isGenreModal, setIsGenreModal] = useState<boolean>(false);
+  const [isModal, setIsModal] = useState<boolean>(false);
+  const [signature, setSignature] = useState<string>(editForm?.guaranteeImage);
+  const [keywordList, setKeywordList] = useState<string[]>(editForm?.keywords);
+  const [genre, setGenre] = useState<string>(editForm?.genre);
+  const [fileList, setFileList] = useState<File[]>([]);
+  const [responseData, setResponseData] = useState<{
+    artworkId: number;
+    turn: number;
+  }>({ artworkId: 0, turn: 0 });
+  const [isErrorModal, setIsErrorModal] = useState<boolean>(false);
+
+  console.log(editForm);
+
+  if (getToken().roles !== 'ROLE_ARTIST') {
+    router.push('/home');
+  }
+
+  const handleRemoveFile = (targetName: string): void => {
+    const newFileList = fileList.filter((file) => {
+      return file.name !== targetName;
+    });
+    setFileList(newFileList);
+    setValue('image', newFileList as any);
+  };
+
+  const {
+    register,
+    setValue,
+    watch,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<Artwork>({
+    defaultValues: {
+      title: editForm?.title,
+      productionYear: editForm?.productionYear,
+      description: editForm?.description,
+      material: editForm?.material,
+      frame: editForm?.frame,
+      width: editForm?.artWorkSize?.width,
+      length: editForm?.artWorkSize?.length,
+      height: editForm?.artWorkSize?.height,
+      size: editForm?.artWorkSize?.size,
+      price: editForm?.price,
+      status: editForm?.status,
+      statusDescription: editForm?.statusDescription,
+    },
+  });
+
+  const handleImage = (e) => {
+    const files = e.target.files;
+    if (fileList?.length <= 5 && fileList?.length + files?.length <= 5) {
+      const newFileList: any = [];
+      for (const i of files) {
+        newFileList.push(i);
+      }
+      setFileList((prev) => prev.concat(newFileList));
+    }
+  };
+
+  useEffect(() => {
+    if (keywordList.length > 0) {
+      setValue('keywords', keywordList);
+    }
+    if (genre) {
+      setValue('genre', genre);
+    }
+    if (signature) {
+      setValue('guaranteeImage', signature);
+    }
+  }, [keywordList, setValue, genre, signature]);
+
+  const { mutate, isLoading: isLoadingPost } = usePostArtwork(setIsErrorModal);
+  const guaranteeRef = useRef<HTMLDivElement>(null);
+
+  const onSubmit = async (form: Artwork) => {
+    const {
+      title,
+      productionYear,
+      description,
+      material,
+      frame,
+      width,
+      length,
+      height,
+      size,
+      price,
+      status,
+      statusDescription,
+    } = form;
+    const formData = new FormData();
+
+    const guarantee = await toBlob(guaranteeRef.current as HTMLDivElement);
+
+    formData.append('title', title);
+    formData.append('productionYear', productionYear + '');
+    formData.append('description', description);
+    formData.append('material', material);
+    formData.append('frame', (frame + '' === '있음') + '');
+    formData.append('width', width + '');
+    formData.append('length', length + '');
+    formData.append('height', height + '');
+    formData.append('size', size);
+    formData.append('price', price + '');
+    formData.append('status', status);
+    formData.append('statusDescription', statusDescription);
+    formData.append('keywords', keywordList + '');
+
+    if (fileList.length == 1) {
+      formData.append('image', fileList[0]);
+    } else {
+      for (const i of fileList) {
+        formData.append('image', i);
+      }
+    }
+
+    if (genre) {
+      formData.append('genre', genre);
+    }
+
+    if (guarantee) {
+      formData.append('guaranteeImage', guarantee, 'image/png');
+    }
+
+    mutate(formData);
+  };
+
+  if (isGuaranteeModal)
+    return (
+      <GuaranteeModal
+        onCloseModal={() => setIsGuaranteeModal(false)}
+        setSignature={setSignature}
+      />
+    );
+
+  if (isKeywordModal)
+    return (
+      <KeywordModal
+        keywordList={keywordList}
+        setKeywordList={setKeywordList}
+        onCloseModal={() => setIsKeywordModal(false)}
+      />
+    );
+
+  if (isGenreModal)
+    return (
+      <GenreModal
+        genre={genre}
+        setGenre={setGenre}
+        onCloseModal={() => setIsGenreModal(false)}
+      />
+    );
+
+  if (isLoadingPost) {
+    return <Loader />;
+  }
+  return (
+    <Layout>
+      <Modal
+        message={`${responseData?.turn}회 경매에 등록 완료되었습니다.
+마이페이지>판매활동>등록된 작품에서 작품내역을 확인해보세요.`}
+        isModal={isModal}
+        onCloseModal={() => {
+          router.replace(`/auction/view?id=${responseData.artworkId}`);
+        }}
+        onAccept={() => {
+          router.replace(`/auction/view?id=${responseData.artworkId}`);
+        }}
+      />
+      <Modal
+        message={`현재 예정된 중인 경매가 없습니다. 죄송합니다.`}
+        isModal={isErrorModal}
+        onCloseModal={() => {
+          setIsErrorModal(false);
+        }}
+        onAccept={() => {
+          setIsErrorModal(false);
+        }}
+      />
+      <form className="w-full space-y-3" onSubmit={handleSubmit(onSubmit)}>
+        <Navigate right_message="완료" />
+        <div className="flex">
+          <label htmlFor="fileImage">
+            <div className="mr-0 flex h-[60px] w-[60px] cursor-pointer flex-col items-center justify-center rounded border-[1px] border-[#DBDBDB]">
+              <Image
+                src="/svg/icons/icon_camera_black.svg"
+                alt="camera"
+                width={17}
+                height={17}
+              />
+              <div className="text-12 text-[#999999]">
+                {fileList.length > 0 ? `${fileList.length}/5` : '0/5'}
+              </div>
+            </div>
+          </label>
+          {fileList.length > 0 && (
+            <div className="flex flex-wrap">
+              {fileList.map((file, idx) => (
+                <FileItem
+                  handler={handleRemoveFile}
+                  key={'' + idx}
+                  file={file}
+                />
+              ))}
+            </div>
+          )}
+          <input
+            multiple
+            type="file"
+            id="fileImage"
+            className="hidden"
+            {...register('image')}
+            onChange={handleImage}
+          />
+        </div>
+        <div>
+          <Input
+            type="text"
+            label="작품명"
+            placeholder="작품명을 입력해주세요"
+            register={register('title', { required: true })}
+          />
+          <button onClick={() => setIsKeywordModal(true)} className="relative">
+            <div className="flex h-[38px] w-[92px] items-center rounded-[4px] border border-[#D8D8D8] pl-3 text-[13px] text-[#999999]">
+              태그추가
+            </div>
+            <div className="absolute left-[63px] bottom-0 flex h-full items-center">
+              <Image
+                src="/svg/icons/icon_plus_gray.svg"
+                alt="tag"
+                width={20}
+                height={20}
+              />
+            </div>
+          </button>
+          <div className="mt-3 flex flex-wrap">
+            {keywordList?.map((name) => (
+              <KeywordBox text={name} key={name} focused />
+            ))}
+          </div>
+        </div>
+        <Input
+          type="number"
+          label="제작연도"
+          min={2010}
+          placeholder="숫자만 입력해주세요. ex)2022"
+          register={register('productionYear', { required: true })}
+        />
+        <div>
+          <div className="flex justify-between">
+            <label htmlFor="description" className="text-14 leading-8">
+              작품설명
+            </label>
+            <div className="text-14 text-[#999999]">
+              <span
+                className={`${
+                  watch('description') ? 'text-[#191919]' : 'text-[#999999]'
+                }`}
+              >
+                {watch('description')?.length || 0}
+                /1000
+              </span>
+            </div>
+          </div>
+          <textarea
+            id="content"
+            maxLength={1000}
+            placeholder="작품에 대해 자세히 기입해주세요."
+            className="h-[150px] w-full resize-none overflow-hidden rounded-[4px] border-[#D8D8D8] text-[13px] placeholder-[#999999] placeholder:text-14"
+            {...register('description', { required: true })}
+          />
+        </div>
+        <Input
+          type="text"
+          label="재료"
+          placeholder="사용한 재료를 입력해주세요."
+          register={register('material', { required: true })}
+        />
+        <div onClick={() => setIsGenreModal(true)}>
+          <label className="text-14 leading-8">장르</label>
+          <div
+            className={`flex h-[52px] w-full cursor-pointer items-center rounded-[4px] border border-[#D8D8D8] pl-3 text-[13px] ${
+              genre ? 'text-[#191919]' : 'text-[#999999]'
+            }`}
+          >
+            {genre ? genre : '선택하기'}
+          </div>
+        </div>
+        <Select
+          name="frame"
+          setValue={setValue}
+          options={IS_FRAME}
+          label="액자"
+        />
+        <div>
+          <span className="text-14">크기/호수</span>
+          <article className="flex gap-4">
+            <Input
+              type="number"
+              min={0}
+              placeholder="가로"
+              className=""
+              register={register('width', { required: true })}
+              unit="cm"
+            />
+            <Input
+              type="number"
+              min={0}
+              placeholder="세로"
+              className=""
+              register={register('length', { required: true })}
+              unit="cm"
+            />
+            <Input
+              type="number"
+              min={0}
+              placeholder="높이"
+              className=""
+              register={register('height', { required: true })}
+              unit="cm"
+            />
+          </article>
+          <article className="w-[calc((100%-2rem)/3)]">
+            <Input
+              type="number"
+              placeholder="10"
+              unit="호"
+              register={register('size', {
+                validate: (value) =>
+                  CANVAS_SIZE.includes(value) || '호수를 확인해주세요.',
+              })}
+            />
+            {errors.size && <ErrorMessage message={errors.size.message} />}
+          </article>
+        </div>
+        <Input
+          type="text"
+          label="경매 시작가"
+          placeholder="작품 최소 가격을 설정해주세요."
+          register={register('price', { required: true })}
+          unit="원"
+        />
+        <Select
+          name="status"
+          setValue={setValue}
+          options={ARTWORK_STATUS}
+          label="작품 상태"
+        />
+        <textarea
+          id="content"
+          maxLength={1000}
+          placeholder="작품상태에 대해 자세히 기입해주세요."
+          className="h-[150px] w-full resize-none overflow-hidden rounded-[4px] border-[#D8D8D8] text-[13px] placeholder-[#999999] placeholder:text-14  "
+          {...register('statusDescription', { required: true })}
+        />
+        <div
+          className="w-full cursor-pointer"
+          onClick={() => setIsGuaranteeModal(true)}
+        >
+          <label htmlFor="statusDetail" className="text-14 leading-8">
+            작품 보증서
+          </label>
+          {signature ? (
+            <div
+              className="flex h-[128px] w-full cursor-pointer items-center justify-center overflow-hidden rounded border border-[#DBDBDB] p-4"
+              onClick={() => setIsGuaranteeModal(true)}
+            >
+              <Image src={signature} width={163} height={91} alt="guarantee" />
+            </div>
+          ) : (
+            <div className="relative">
+              <div className="flex h-[52px] w-full items-center rounded-[4px] border border-[#D8D8D8] pl-3 text-[13px] text-[#999999]">
+                전자 서명이 필요합니다.
+              </div>
+              <div
+                onClick={() => setIsGuaranteeModal(true)}
+                className="absolute right-4 bottom-0 flex h-[52px] cursor-pointer items-center"
+              >
+                <Image
+                  src="/svg/icons/icon_pencil_gray.svg"
+                  alt="setting"
+                  className="cursor-pointer"
+                  width="23"
+                  height="0"
+                />
+              </div>
+            </div>
+          )}
+        </div>
+        {user &&
+          watch('title') &&
+          watch('productionYear') &&
+          watch('width') &&
+          watch('length') &&
+          watch('height') &&
+          watch('genre') &&
+          signature && (
+            <div
+              ref={guaranteeRef}
+              className="m-auto min-w-[327px] flex-col items-center justify-center py-9"
+            >
+              <div className="text-center text-16 font-semibold tracking-[0.3em]">
+                작 품 보 증 서
+              </div>
+              <p className="text-center text-[8px] font-light tracking-[-0.05em] text-[#A5A5A5]">
+                CERTIFICATE OF AUTHENTICITY
+              </p>
+              <div className="relative mx-auto mt-7 h-[74px] w-[116px]">
+                <Image
+                  src={makeBlob(fileList[0])}
+                  fill
+                  className="object-cover"
+                  alt="artwork"
+                />
+              </div>
+              <div className="mt-3 flex justify-center text-11 leading-5">
+                <div className="flex-col font-semibold">
+                  <p>작가</p>
+                  <p>제목</p>
+                  <p>제작년도</p>
+                  <p>작품크기</p>
+                  <p>제작기법</p>
+                </div>
+                <div className="ml-12 flex-col">
+                  <p>{user?.nickname}</p>
+                  <p>{watch('title')}</p>
+                  <p>{watch('productionYear')}</p>
+                  <p>{`${watch('width')}x${watch('length')}x${watch(
+                    'height',
+                  )}cm`}</p>
+                  <p>{watch('genre')}</p>
+                </div>
+              </div>
+              <div className="mt-4 flex-col">
+                <div className="flex items-center justify-center">
+                  <Image src={signature} width={50} height={50} alt="artwork" />
+                </div>
+                <div className="mt-2 flex-col items-center justify-center">
+                  <div className="mx-auto w-[70px] border-t border-t-black pb-[3px]" />
+                  <div className="text-center text-[8px]  text-[#A5A5A5]">
+                    Artist Signature
+                  </div>
+                </div>
+              </div>
+              <ul className="mt-3 w-full list-none text-center text-[8px]">
+                <li className="w-full  text-black  before:mr-2  before:content-['\2022']">
+                  본 작품은 위에 서명한 작가의 작품임을 보증합니다.
+                </li>
+                <li className="w-full text-black  before:mr-2  before:content-['\2022']">
+                  본 작품은 일체의 모작, 위작이 아님을 보증합니다.
+                </li>
+                <li className="w-full text-black  before:mr-2  before:content-['\2022']">
+                  본 보증서는 작품 보증 이외 환불, 교환 등의 목적으로 사용이
+                  불가합니다.
+                </li>
+              </ul>
+              <p className="my-3 text-center text-[8px]">{today()}</p>
+              <div className="flex items-center justify-center text-brand">
+                <Image
+                  src="/svg/post/logo_small.svg"
+                  width={60}
+                  height={10}
+                  alt="logo"
+                />
+              </div>
+            </div>
+          )}
+
+        <div className="relative h-[336px]">
+          <div className="absolute -left-6 -bottom-10 h-[376px] w-[375px]">
+            <div className="mt-12 h-4 bg-[#F8F8FA]"></div>
+            <div className="px-6 text-12">
+              <p className="mt-8 font-medium">
+                다음의 경우 작품등록이 제외될 수 있습니다.
+              </p>
+              <ul className="mt-3 ml-3 w-fit list-disc space-y-2 tracking-tight text-[#767676]">
+                <li>
+                  작품의 선정성, 유해성이 통신판매업 시행령(2019) 기준에 맞지
+                  아니 하다고 판단되는 경우
+                </li>
+                <li>
+                  제출된 자료의 내용이 미흡하거나, 허위로 기재된 사실이 밝혀질
+                  경우
+                </li>
+                <li>
+                  제출된 작품 이미지로 작품의 형태 유무의 대부분을 판단할 수
+                  없는 경우
+                </li>
+                <li>
+                  과반 이상의 심사위원이 작품이 완성되지 않았다고 판단하거나
+                  프로그램의 취지에 맞지 아니하다고 판단될 경우
+                </li>
+                <li>유사 온라인 아트플랫폼에 이미 등록되었거나 확인될 경우</li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </form>
+    </Layout>
+  );
+}

--- a/src/pages/profile/selling/index.tsx
+++ b/src/pages/profile/selling/index.tsx
@@ -8,7 +8,6 @@ import SellingItem from '@components/profile/selling/SellingItem';
 import { useRouter } from 'next/router';
 import None from '@components/common/None';
 import SellingModal from '@components/profile/selling/SellingModal';
-import artworkApi from '@apis/artwork/artworkApi';
 
 export default function Selling() {
   const router = useRouter();
@@ -16,6 +15,7 @@ export default function Selling() {
   const [thisId, setThisId] = useState<number>(0);
 
   const handleOption = (e) => {
+    console.log(1);
     e.stopPropagation();
     setThisId(e.target.id);
     setIsModal(true);
@@ -27,6 +27,7 @@ export default function Selling() {
   const {
     data: [registered, processing, sales_finished],
   } = useGetMyArtWork();
+
   return (
     <Layout>
       {isModal && (
@@ -59,12 +60,6 @@ export default function Selling() {
                   key={item.id}
                   sellingItem={item}
                   handleOption={handleOption}
-                  onClick={() => {
-                    router.push({
-                      pathname: '/auction/view',
-                      query: { id: item.id },
-                    });
-                  }}
                 />
               ))
             ) : (
@@ -80,12 +75,6 @@ export default function Selling() {
                   key={item.id}
                   sellingItem={item}
                   handleOption={handleOption}
-                  onClick={() => {
-                    router.push({
-                      pathname: '/auction/view',
-                      query: { id: item.id },
-                    });
-                  }}
                 />
               ))
             ) : (
@@ -101,12 +90,6 @@ export default function Selling() {
                   key={item.id}
                   sellingItem={item}
                   handleOption={handleOption}
-                  onClick={() => {
-                    router.push({
-                      pathname: '/auction/view',
-                      query: { id: item.id },
-                    });
-                  }}
                 />
               ))
             ) : (

--- a/src/pages/profile/selling/index.tsx
+++ b/src/pages/profile/selling/index.tsx
@@ -7,35 +7,37 @@ import useGetMyArtWork from '@hooks/queries/artwork/useGetMyArtWork';
 import SellingItem from '@components/profile/selling/SellingItem';
 import { useRouter } from 'next/router';
 import None from '@components/common/None';
+import SellingModal from '@components/profile/selling/SellingModal';
+import artworkApi from '@apis/artwork/artworkApi';
 
 export default function Selling() {
   const router = useRouter();
   const [isModal, setIsModal] = useState<boolean>(false);
-  const handleOption = () => {
+  const [thisId, setThisId] = useState<number>(0);
+
+  const handleOption = (e) => {
+    e.stopPropagation();
+    setThisId(e.target.id);
     setIsModal(true);
   };
   const handleCloseModal = () => {
     setIsModal(false);
   };
-  const handleAccept = () => {
-    setIsModal(true);
-  };
+
   const {
     data: [registered, processing, sales_finished],
   } = useGetMyArtWork();
-  console.log(registered, processing, sales_finished);
   return (
     <Layout>
-      <Modal
-        isModal={isModal}
-        // isMain
-        onCloseModal={handleCloseModal}
-        // message="경매 중으로 넘어간 작품은 수정/삭제가 불가능 합니다."
-        message="아직 준비 중인 서비스입니다."
-        // denyMessage="수정"
-        className="top-5"
-        onAccept={handleAccept}
-      />
+      {isModal && (
+        <SellingModal
+          onCloseModal={handleCloseModal}
+          message="경매 중으로 넘어간 작품은 수정/삭제가 불가능 합니다."
+          className="top-5"
+          thisId={thisId}
+        />
+      )}
+
       <Navigate isRightButton={false} message="판매활동" />
       <Tab.Group>
         <Tab.List className="w-full text-14 ">

--- a/src/pages/profile/selling/index.tsx
+++ b/src/pages/profile/selling/index.tsx
@@ -1,21 +1,17 @@
 import Layout from '@components/common/Layout';
-import Modal from '@components/common/Modal';
 import Navigate from '@components/common/Navigate';
 import React, { useState } from 'react';
 import { Tab } from '@headlessui/react';
 import useGetMyArtWork from '@hooks/queries/artwork/useGetMyArtWork';
 import SellingItem from '@components/profile/selling/SellingItem';
-import { useRouter } from 'next/router';
 import None from '@components/common/None';
 import SellingModal from '@components/profile/selling/SellingModal';
 
 export default function Selling() {
-  const router = useRouter();
   const [isModal, setIsModal] = useState<boolean>(false);
   const [thisId, setThisId] = useState<number>(0);
 
   const handleOption = (e) => {
-    console.log(1);
     e.stopPropagation();
     setThisId(e.target.id);
     setIsModal(true);


### PR DESCRIPTION
## 🧑‍💻 PR 내용

1. 작품 삭제 및 수정 페이지 구현하였습니다.
- 수정 시 서명은 다시 해야 합니다.
- 삭제 후 바로 업데이트가 안되는데, 이 부분은 다른 우선순위 작업 후 추후에 수정하겠습니다.
2. 그 외의 수정사항들 반영하였습니다.
- 전시회 없을 때 화면
- 경매 시작 전 status 변경
- type=textarea 추가 (기획자 의견 반영)
3. 전화번호는, 각 페이지에서 members/me api 호출했을 때 telephone이 비어있으면 edit페이지로 redirect하도록 구현했습니다
추후 위에 토스트창도 함께 뜨도록 추가구현할 예정입니다.

## 📸 스크린샷
![Kapture 2023-02-18 at 21 25 07](https://user-images.githubusercontent.com/62178788/219865622-44f575ed-96d4-49bd-b5ff-4e8405153766.gif)
![Kapture 2023-02-18 at 21 26 36](https://user-images.githubusercontent.com/62178788/219865669-72054290-78fa-46d8-91e4-d5bd48888208.gif)



