### PR TITLE
전시회 모달 수정

### DIFF
--- a/src/components/exhibition/Modal.tsx
+++ b/src/components/exhibition/Modal.tsx
@@ -1,6 +1,7 @@
 import Image from 'next/image';
 import tw from 'tailwind-styled-components';
 import { useRouter } from 'next/router';
+import styled from 'styled-components';
 
 interface ModalProps {
   id: number;
@@ -41,11 +42,27 @@ text-[#424242] text-20 flex justify-between font-bold `;
 const EducationDiv = tw.div<DefaultProps>`
 text-[#191919] text-14 pt-1`;
 
-const DescriptionDiv = tw.div<DefaultProps>`
-text-[#191919] text-14 pt-3`;
-
 const ModalButton = tw.div`
 bg-[#FFFFFF] rounded-[4px] text-[#191919] text-14 flex items-center justify-center cursor-pointer px-10 py-4 max-[400px]:px-8 max-[370px]:px-7
+`;
+
+const DescriptionDiv = styled.div`
+  font-size: 14px;
+  height: 135px;
+  overflow-y: auto;
+  padding-right: 15px;
+  ::-webkit-scrollbar {
+    width: 3px;
+  }
+  ::-webkit-scrollbar-track {
+    background-color: #ffffff;
+    border-radius: 30px;
+    width: 1px;
+  }
+  ::-webkit-scrollbar-thumb {
+    background-color: #191919;
+    border-radius: 30px;
+  }
 `;
 
 export default function Modal({

--- a/src/pages/exhibition/detail.tsx
+++ b/src/pages/exhibition/detail.tsx
@@ -9,6 +9,7 @@ import { Swiper } from 'swiper/react';
 import { useState } from 'react';
 import { useRouter } from 'next/router';
 import { useGetExhibitionItem } from '@hooks/queries/useGetExhibition';
+import useWindowSize from '@hooks/useWindowSize';
 
 export default function ExhibitionArt() {
   const [isOpen, setIsOpen] = useState<boolean>(false);
@@ -19,6 +20,8 @@ export default function ExhibitionArt() {
   const id = Number(router.query.id);
 
   const { data: art } = useGetExhibitionItem(id);
+
+  const { height } = useWindowSize();
 
   const onCloseModal = () => {
     setIsOpen(false);
@@ -153,6 +156,7 @@ export default function ExhibitionArt() {
             )}
             <Modal
               $open={isOpen}
+              $height={height}
               title={art.title}
               education={art.education}
               description={art.description}


### PR DESCRIPTION
## 🧑‍💻 PR 내용

작품 설명이 길어지면서 모달 위치가 변경됨에 따라 
작품 설명 섹션에 높이를 설정해주었고 높이보다 텍스트의 길이가 긴 경우에는 스크롤 바를 생성하도록 수정했습니다.

## 📸 스크린샷

![녹화_2023_02_24_17_11_49_437](https://user-images.githubusercontent.com/79186378/221127666-ade4b355-04d3-4a7e-86cc-6e9dce3202e0.gif)
