### PR TITLE
router.push -> Link로 수정

### DIFF
--- a/src/components/auction/ArtWorkItem.tsx
+++ b/src/components/auction/ArtWorkItem.tsx
@@ -1,5 +1,6 @@
 import { priceToString } from '@utils/priceToString';
 import Image from 'next/image';
+import Link from 'next/link';
 import { useRouter } from 'next/router';
 import tw from 'tailwind-styled-components';
 
@@ -22,46 +23,39 @@ export default function ArtWorkItem({
   material,
   ...rest
 }: ArtWorkItemProps) {
-  const router = useRouter();
   return (
-    <ArtWorkItemTag
-      {...rest}
-      onClick={() => {
-        router.push({
-          pathname: `/auction/view`,
-          query: { id },
-        });
-      }}
-    >
-      <section className="relative h-[12.5rem] overflow-hidden">
-        <Image
-          alt="image"
-          src={mainImage}
-          quality={100}
-          fill
-          className="rounded-xl object-cover"
-        />
-      </section>
-      <section className="absolute inset-x-0 bottom-0 m-auto rounded-b-xl bg-white px-3 py-4">
-        <article className="text-16 font-medium">
-          {title.length > 20 ? `${title.slice(0, 20)}...` : title}
-        </article>
-        <article className="my-1 flex gap-2 text-14 text-[#767676]">
-          <span>{material}</span>|
-          <span>
-            {`${artWorkSize.width}x${artWorkSize.length}x${
-              artWorkSize.height
-            }cm ${artWorkSize.size && '(' + artWorkSize.size + ')'}`}
-          </span>
-          |<span>{productionYear}</span>
-        </article>
-        <article className="flex items-center gap-2">
-          <span className="text-18 font-bold">{`${priceToString(
-            topPrice,
-          )}원`}</span>
-          <span className="text-14">현재가</span>
-        </article>
-      </section>
-    </ArtWorkItemTag>
+    <Link href={`/auction/${id}`}>
+      <ArtWorkItemTag {...rest}>
+        <section className="relative h-[12.5rem] overflow-hidden">
+          <Image
+            alt="image"
+            src={mainImage}
+            quality={100}
+            fill
+            className="rounded-xl object-cover"
+          />
+        </section>
+        <section className="absolute inset-x-0 bottom-0 m-auto rounded-b-xl bg-white px-3 py-4">
+          <article className="text-16 font-medium">
+            {title.length > 20 ? `${title.slice(0, 20)}...` : title}
+          </article>
+          <article className="my-1 flex gap-2 text-14 text-[#767676]">
+            <span>{material}</span>|
+            <span>
+              {`${artWorkSize.width}x${artWorkSize.length}x${
+                artWorkSize.height
+              }cm ${artWorkSize.size && '(' + artWorkSize.size + ')'}`}
+            </span>
+            |<span>{productionYear}</span>
+          </article>
+          <article className="flex items-center gap-2">
+            <span className="text-18 font-bold">{`${priceToString(
+              topPrice,
+            )}원`}</span>
+            <span className="text-14">현재가</span>
+          </article>
+        </section>
+      </ArtWorkItemTag>
+    </Link>
   );
 }

--- a/src/components/common/Tab.tsx
+++ b/src/components/common/Tab.tsx
@@ -49,8 +49,6 @@ interface TabItemProps {
 }
 
 export default function Tab() {
-  const router = useRouter();
-
   return (
     <TabBox>
       <TabList>

--- a/src/components/common/TabItem.tsx
+++ b/src/components/common/TabItem.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { useRouter } from 'next/router';
 import Image from 'next/image';
+import Link from 'next/link';
 
 interface TabItemProps {
   tabItem: {
@@ -27,12 +28,10 @@ export default function TabItem({ tabItem }: TabItemProps) {
   };
 
   return (
-    <div
+    <Link
+      href={`/${tabItem.name}`}
       className="m-auto cursor-pointer"
       key={tabItem.id}
-      onClick={() => {
-        handleTabItem(tabItem.name);
-      }}
       onMouseEnter={() => {
         handleMouseEnter(tabItem.name);
       }}
@@ -64,6 +63,6 @@ export default function TabItem({ tabItem }: TabItemProps) {
           {tabItem.word}
         </div>
       </div>
-    </div>
+    </Link>
   );
 }


### PR DESCRIPTION
## 🧑‍💻 PR 내용

다음과 같은 이유로 인해 router.push -> \<Link />로 수정하였습니다.
- router.push : <a>태그를 만들지 않음 -> SEO에 최적화 X
- `<Link/>` : <a>태그 만듬 & 이동할 때 페이지를 reloading하지 않음. SPA로 구현(CSR)
- `<a>` : url로 이동할 때 새로운 페이지를 만듬


## 📸 스크린샷

- 기존(router.push) 사용

<img width="1154" alt="스크린샷 2023-05-24 오후 6 40 28" src="https://github.com/guesung/atties-ver2.0/assets/62178788/a976bdac-bf06-47dc-9095-10819c4989ee">

- 변경 후(\<Link /> 태그 사용)

<img width="1073" alt="스크린샷 2023-05-24 오후 6 40 55" src="https://github.com/guesung/atties-ver2.0/assets/62178788/ec22d804-fd9e-42e7-91de-b7fef803a263">

